### PR TITLE
Add GitHub Actions checks, test script, and skip-main flag to uki-setup

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,35 @@
+name: checks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  fedora-checks:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:43
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install check dependencies
+        run: |
+          dnf install -y \
+            bash \
+            coreutils \
+            diffutils \
+            findutils \
+            grep \
+            sed \
+            util-linux \
+            which \
+            shellcheck
+
+      - name: Bash syntax checks
+        run: bash -n uki-setup.sh tests/test_uki_setup.sh
+
+      - name: ShellCheck
+        run: shellcheck -P . uki-setup.sh tests/test_uki_setup.sh
+
+      - name: Project checks
+        run: bash tests/test_uki_setup.sh

--- a/README.md
+++ b/README.md
@@ -124,6 +124,25 @@ Leave empty to auto-detect common Fedora paths.
 
 ---
 
+
+## Continuous integration checks
+
+GitHub Actions now runs checks in a Fedora container (`fedora:41`) on every push and pull request. The workflow verifies:
+
+- Bash syntax for `uki-setup.sh` and test scripts.
+- `shellcheck` linting.
+- A project check script that sources `uki-setup.sh` with `UKI_SETUP_SKIP_MAIN=1` and validates the generated helper/plugin templates.
+
+Run the same checks locally with:
+
+```bash
+bash -n uki-setup.sh tests/test_uki_setup.sh
+shellcheck -P . uki-setup.sh tests/test_uki_setup.sh
+bash tests/test_uki_setup.sh
+```
+
+---
+
 ## Files created by setup
 
 Running `uki-setup.sh` creates/updates:

--- a/tests/test_uki_setup.sh
+++ b/tests/test_uki_setup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TMPDIR_WORK="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_WORK"
+}
+trap cleanup EXIT
+
+export UKI_SETUP_SKIP_MAIN=1
+# shellcheck source=uki-setup.sh
+source "$REPO_ROOT/uki-setup.sh"
+
+BUILD_SCRIPT="$TMPDIR_WORK/usr-local-sbin-uki-build.sh"
+INSTALL_PLUGIN="$TMPDIR_WORK/usr-lib-kernel-install.d-90-uki-dracut.install"
+BACKUP_ROOT="$TMPDIR_WORK/backups"
+EFI_DIR="$TMPDIR_WORK/esp/EFI/Linux"
+CMDLINE="root=UUID=test-uuid rw quiet"
+AUTO_DETECT_CMDLINE=0
+EFI_STUB="/usr/lib/systemd/boot/efi/linuxx64.efi.stub"
+
+phase_write_build_script
+
+[[ -x "$BUILD_SCRIPT" ]] || {
+    echo "Expected build script to be executable at $BUILD_SCRIPT"
+    exit 1
+}
+
+if grep -q '__EFI_DIR__\|__CMDLINE__\|__AUTO_DETECT_CMDLINE__\|__EFI_STUB__' "$BUILD_SCRIPT"; then
+    echo "Template placeholders were not fully substituted in build script"
+    exit 1
+fi
+
+grep -q "EFI_DIR=\"$EFI_DIR\"" "$BUILD_SCRIPT"
+grep -q "CMDLINE=\"$CMDLINE\"" "$BUILD_SCRIPT"
+grep -q 'AUTO_DETECT_CMDLINE=0' "$BUILD_SCRIPT"
+grep -q "EFI_STUB=\"$EFI_STUB\"" "$BUILD_SCRIPT"
+
+phase_write_plugin
+
+[[ -x "$INSTALL_PLUGIN" ]] || {
+    echo "Expected install plugin to be executable at $INSTALL_PLUGIN"
+    exit 1
+}
+
+grep -q "BUILD_SCRIPT=\"$BUILD_SCRIPT\"" "$INSTALL_PLUGIN"
+grep -Fq "UKI=\"${EFI_DIR}/linux-\${KERNEL_VER}.efi\"" "$INSTALL_PLUGIN"
+
+echo "All local UKI setup checks passed."

--- a/uki-setup.sh
+++ b/uki-setup.sh
@@ -471,7 +471,7 @@ phase_summary() {
     echo "    ${INSTALL_PLUGIN} ← auto-trigger on kernel installs"
     echo ""
     echo "  UKIs are stored in: ${EFI_DIR}/"
-    ls -lh "${EFI_DIR}/"*.efi 2>/dev/null | sed 's/^/    /' || true
+    find "${EFI_DIR}" -maxdepth 1 -type f -name "*.efi" -exec ls -lh {} + 2>/dev/null | sed 's/^/    /' || true
     echo ""
     echo "  Current UEFI boot entries:"
     efibootmgr -v 2>/dev/null | grep -E 'BootOrder|Boot[0-9A-Fa-f]{4}' | sed 's/^/    /' || true
@@ -493,10 +493,12 @@ phase_summary() {
 # Main
 # =============================================================================
 
-phase_preflight
-phase_deps
-phase_write_build_script
-phase_write_plugin
-phase_disable_bls_plugins
-phase_initial_build
-phase_summary
+if [[ "${UKI_SETUP_SKIP_MAIN:-0}" -ne 1 ]]; then
+    phase_preflight
+    phase_deps
+    phase_write_build_script
+    phase_write_plugin
+    phase_disable_bls_plugins
+    phase_initial_build
+    phase_summary
+fi


### PR DESCRIPTION
### Motivation

- Add automated CI to lint and validate `uki-setup.sh` and its generated artifacts in a Fedora container on push and PRs. 
- Allow test harnesses to source the script without running the main workflow by providing a skip-main switch. 
- Make the post-install summary robust against missing glob matches when listing UKI files.

### Description

- Add `.github/workflows/checks.yml` which runs a Fedora container, installs shell tooling, and executes `bash -n`, `shellcheck`, and the project check script. 
- Add `tests/test_uki_setup.sh` which sets `UKI_SETUP_SKIP_MAIN=1`, sources `uki-setup.sh`, invokes `phase_write_build_script` and `phase_write_plugin`, and validates template substitution and generated file contents. 
- Document the CI checks and local reproduction commands in `README.md`. 
- Modify `uki-setup.sh` to replace `ls -lh "${EFI_DIR}"*.efi` with `find "${EFI_DIR}" -maxdepth 1 -type f -name "*.efi" -exec ls -lh {} +` to avoid shell glob issues. 
- Guard the script main execution with `if [[ "${UKI_SETUP_SKIP_MAIN:-0}" -ne 1 ]]; then ... fi` so tests can source the file safely.

### Testing

- Run `bash -n uki-setup.sh tests/test_uki_setup.sh` to verify Bash syntax, which succeeded. 
- Run `shellcheck -P . uki-setup.sh tests/test_uki_setup.sh` to lint the scripts, which succeeded. 
- Run the project check `bash tests/test_uki_setup.sh` to validate generated artifacts and template substitution, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acafa84748832a993c44a7cf9b29a7)