### PR TITLE
ci: pin Fedora checks workflow to fedora:41

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,8 @@ jobs:
   fedora-checks:
     runs-on: ubuntu-latest
     container:
-      image: fedora:43
+      # Keep this pinned to a stable Fedora release so CI remains reproducible.
+      image: fedora:41
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### Motivation
- The Fedora CI container image was drifting and causing the checks workflow to fail, so the container image is pinned to a stable Fedora release to keep CI reproducible and aligned with the repository documentation (`.github/workflows/checks.yml`).

### Description
- Changed the GitHub Actions Fedora container image from `fedora:43` to `fedora:41` and added a short inline comment explaining the pinning in `.github/workflows/checks.yml`.

### Testing
- Ran `bash -n uki-setup.sh tests/test_uki_setup.sh` which completed successfully.
- Executed `bash tests/test_uki_setup.sh` which completed successfully and reported all local checks passed.
- Attempted `shellcheck -P . uki-setup.sh tests/test_uki_setup.sh` but `shellcheck` could not be installed in this environment due to blocked package repository/proxy (403), so linting will run in the Fedora container during CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb323b400832aa00bd74e830eb46a)