### PR TITLE
docs: add one-line GitHub download-and-run command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ for any existing files it overwrites.
 
 ## Quick start
 
+One-line download + run from GitHub (replace `<OWNER>` with the repo owner):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/<OWNER>/Fedora-UKI-Script/main/uki-setup.sh | sudo bash
+```
+
 1. Clone this repository.
 2. Edit configuration values at the top of `uki-setup.sh` (especially `CMDLINE`).
 3. Run:


### PR DESCRIPTION
### Motivation
- Provide a simple copy/paste one-liner so users can quickly download and run `uki-setup.sh` directly from GitHub with an explicit owner placeholder.

### Description
- Add a Quick start entry containing the one-line command `curl -fsSL https://raw.githubusercontent.com/<OWNER>/Fedora-UKI-Script/main/uki-setup.sh | sudo bash` and a note to replace `<OWNER>` with the repository owner.

### Testing
- Ran `bash -n uki-setup.sh` to validate script syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb4317cb4832a9e07dd5ad3018a2d)