### PR TITLE
Auto-mount ESP during preflight and UKI build flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project is intended for systems booting in **UEFI mode** with a mounted **E
 - Linux distribution with `dracut`, `kernel-install`, and `efibootmgr` available.
 - UEFI boot mode.
 - Root privileges.
-- ESP mounted at `/boot/efi` or `/efi`.
+- ESP mounted at `/boot/efi` or `/efi` (the script now attempts to auto-mount it when possible).
 
 > [!DANGER]
 > **Make a full system backup before running this script.** A tested restore path (snapshot rollback, rescue image, or offline backup) is strongly recommended.
@@ -227,7 +227,8 @@ sudo rm -f \
 
 ## Troubleshooting
 
-- **UEFI not detected**: Ensure firmware boot mode is UEFI and ESP is mounted.
+- **UEFI not detected**: Ensure firmware boot mode is UEFI and that `efivars`/ESP are accessible.
+- **ESP not mounted**: The script now tries to mount `/boot/efi` or `/efi` automatically (via fstab first, then ESP partition detection). If that still fails, mount it manually and rerun.
 - **UKI fails to boot**: Re-check `CMDLINE` and storage-related boot args.
 - **Missing EFI stub**: Install your distro's systemd-boot package and verify stub path.
 - **No Secure Boot signing**: Install `sbsigntools`; this script only warns when absent.

--- a/uki-setup.sh
+++ b/uki-setup.sh
@@ -70,6 +70,50 @@ die()   { echo "${RED}${BLD}[err]${RST}  $*" >&2; exit 1; }
 hr()    { echo "──────────────────────────────────────────────────────────────"; }
 require_cmd() { command -v "$1" &>/dev/null || die "Required command missing: $1"; }
 
+find_esp_device() {
+    # GPT ESP type GUID: c12a7328-f81f-11d2-ba4b-00a0c93ec93b
+    lsblk -pnro PATH,PARTTYPE,FSTYPE 2>/dev/null \
+        | awk '$2=="c12a7328-f81f-11d2-ba4b-00a0c93ec93b" && tolower($3) ~ /fat|vfat/ {print $1; exit}'
+}
+
+ensure_esp_mounted() {
+    local esp_mount="" esp_dev="" candidate
+
+    esp_mount="$(findmnt -n -o TARGET /boot/efi 2>/dev/null || findmnt -n -o TARGET /efi 2>/dev/null || true)"
+    if [[ -n "$esp_mount" ]]; then
+        info "ESP mounted at ${esp_mount}."
+        return 0
+    fi
+
+    warn "ESP not currently mounted. Attempting automatic mount..."
+
+    # First try fstab-based mount by mount point.
+    for candidate in /boot/efi /efi; do
+        mkdir -p "$candidate"
+        if mount "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
+            info "Mounted ESP at ${candidate} using fstab entry."
+            return 0
+        fi
+    done
+
+    # Fallback: detect the ESP partition and mount directly.
+    esp_dev="$(find_esp_device || true)"
+    if [[ -n "$esp_dev" ]]; then
+        if [[ -d /boot ]]; then
+            candidate="/boot/efi"
+        else
+            candidate="/efi"
+        fi
+        mkdir -p "$candidate"
+        if mount -t vfat "$esp_dev" "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
+            info "Mounted ESP device ${esp_dev} at ${candidate}."
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 backup_path() {
     local src="$1"
     [[ -e "$src" || -L "$src" ]] || return 0
@@ -169,10 +213,7 @@ phase_preflight() {
         info "UEFI environment confirmed."
     fi
 
-    # Verify ESP is mounted
-    if ! findmnt /boot/efi &>/dev/null && ! findmnt /efi &>/dev/null; then
-        die "ESP not mounted at /boot/efi or /efi. Mount it first."
-    fi
+    ensure_esp_mounted || die "ESP not mounted at /boot/efi or /efi and automatic mount failed. Mount it manually, then re-run."
 }
 
 # =============================================================================
@@ -237,6 +278,43 @@ warn()  { echo -e "${YLW}[uki-build]${RST} $*" >&2; }
 die()   { echo -e "${RED}[uki-build]${RST} $*" >&2; exit 1; }
 require_cmd() { command -v "$1" &>/dev/null || die "Required command missing: $1"; }
 
+find_esp_device() {
+    lsblk -pnro PATH,PARTTYPE,FSTYPE 2>/dev/null \
+        | awk '$2=="c12a7328-f81f-11d2-ba4b-00a0c93ec93b" && tolower($3) ~ /fat|vfat/ {print $1; exit}'
+}
+
+ensure_esp_mounted() {
+    local esp_mount="" esp_dev="" candidate
+
+    esp_mount=$(findmnt -n -o TARGET /boot/efi 2>/dev/null || findmnt -n -o TARGET /efi 2>/dev/null || true)
+    if [[ -n "$esp_mount" ]]; then
+        info "ESP mounted at ${esp_mount}"
+        return 0
+    fi
+
+    warn "ESP not mounted. Attempting automatic mount..."
+    for candidate in /boot/efi /efi; do
+        mkdir -p "$candidate"
+        if mount "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
+            info "Mounted ESP at ${candidate} using fstab entry"
+            return 0
+        fi
+    done
+
+    esp_dev=$(find_esp_device || true)
+    if [[ -n "$esp_dev" ]]; then
+        candidate="/boot/efi"
+        [[ -d /boot ]] || candidate="/efi"
+        mkdir -p "$candidate"
+        if mount -t vfat "$esp_dev" "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
+            info "Mounted ESP device ${esp_dev} at ${candidate}"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 KERNEL_VER="${1:-$(uname -r)}"
 KERNEL_IMG="/lib/modules/${KERNEL_VER}/vmlinuz"
 UKI_OUT="${EFI_DIR}/linux-${KERNEL_VER}.efi"
@@ -248,6 +326,7 @@ require_cmd lsblk
 require_cmd efibootmgr
 [[ -f "$KERNEL_IMG" ]] || die "Kernel image not found: ${KERNEL_IMG}"
 mkdir -p "$EFI_DIR"
+ensure_esp_mounted || die "ESP is not mounted and automatic mount failed."
 
 # Build effective cmdline
 if [[ "$AUTO_DETECT_CMDLINE" -eq 1 ]]; then


### PR DESCRIPTION
### Motivation
- Avoid hard-failing when the EFI System Partition (ESP) is present but not mounted so the setup can proceed or self-fix common user setups. 
- Ensure the generated `/usr/local/sbin/uki-build.sh` can also recover when run later (e.g., from `kernel-install` hooks) if the ESP is not mounted.
- Make documentation reflect the improved behavior so users know the script will attempt to mount the ESP automatically.

### Description
- Added `find_esp_device` (detect ESP partition via `lsblk` GUID/FSTYPE) and `ensure_esp_mounted` helpers to `uki-setup.sh` to try mounting `/boot/efi` or `/efi` using fstab first and falling back to mounting the detected ESP device with `-t vfat`.
- Replaced the old preflight hard-fail with `ensure_esp_mounted || die ...` so the script attempts automatic mounting before aborting.
- Injected the same `find_esp_device` / `ensure_esp_mounted` logic into the generated `uki-build.sh` template and enforced it before building a UKI so rebuilds also auto-mount the ESP when possible.
- Updated `README.md` Requirements and Troubleshooting to document the auto-mount behavior and the fallback for manual mounting.

### Testing
- Ran shell syntax checks with `bash -n uki-setup.sh tests/test_uki_setup.sh` which completed successfully.
- Executed the project validation script `bash tests/test_uki_setup.sh` which passed and confirmed generated templates are populated as expected.
- Attempted `shellcheck uki-setup.sh` but `shellcheck` was not available in the environment (not a failure of the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acdb7c80d0832ab36acf5aa00521e8)