### PR TITLE
Improve ESP auto-mount detection across Fedora layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project is intended for systems booting in **UEFI mode** with a mounted **E
 - Linux distribution with `dracut`, `kernel-install`, and `efibootmgr` available.
 - UEFI boot mode.
 - Root privileges.
-- ESP mounted at `/boot/efi` or `/efi` (the script now attempts to auto-mount it when possible).
+- ESP mounted at one of `/boot/efi`, `/efi`, `/boot`, `/boot/EFI`, or `/esp` (the script attempts automatic ESP discovery/mounting).
 
 > [!DANGER]
 > **Make a full system backup before running this script.** A tested restore path (snapshot rollback, rescue image, or offline backup) is strongly recommended.
@@ -228,7 +228,7 @@ sudo rm -f \
 ## Troubleshooting
 
 - **UEFI not detected**: Ensure firmware boot mode is UEFI and that `efivars`/ESP are accessible.
-- **ESP not mounted**: The script now tries to mount `/boot/efi` or `/efi` automatically (via fstab first, then ESP partition detection). If that still fails, mount it manually and rerun.
+- **ESP not mounted**: The script now checks `/boot/efi`, `/efi`, `/boot`, `/boot/EFI`, and `/esp`, then attempts automatic mounting (via fstab first, then ESP partition detection). If that still fails, mount it manually and rerun.
 - **UKI fails to boot**: Re-check `CMDLINE` and storage-related boot args.
 - **Missing EFI stub**: Install your distro's systemd-boot package and verify stub path.
 - **No Secure Boot signing**: Install `sbsigntools`; this script only warns when absent.

--- a/uki-setup.sh
+++ b/uki-setup.sh
@@ -70,16 +70,39 @@ die()   { echo "${RED}${BLD}[err]${RST}  $*" >&2; exit 1; }
 hr()    { echo "──────────────────────────────────────────────────────────────"; }
 require_cmd() { command -v "$1" &>/dev/null || die "Required command missing: $1"; }
 
+ESP_MOUNT_CANDIDATES=(
+    /boot/efi
+    /efi
+    /boot
+    /boot/EFI
+    /esp
+)
+
 find_esp_device() {
     # GPT ESP type GUID: c12a7328-f81f-11d2-ba4b-00a0c93ec93b
     lsblk -pnro PATH,PARTTYPE,FSTYPE 2>/dev/null \
         | awk '$2=="c12a7328-f81f-11d2-ba4b-00a0c93ec93b" && tolower($3) ~ /fat|vfat/ {print $1; exit}'
 }
 
+find_mounted_esp_target() {
+    local candidate target
+
+    for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
+        target="$(findmnt -n -o TARGET "$candidate" 2>/dev/null || true)"
+        [[ -n "$target" ]] && { echo "$target"; return 0; }
+    done
+
+    while read -r target; do
+        [[ -n "$target" ]] && { echo "$target"; return 0; }
+    done < <(findmnt -rn -t vfat,fat -o TARGET 2>/dev/null | awk '$1 ~ /^\// && system("test -d " $1 "/EFI") == 0 {print $1}')
+
+    return 1
+}
+
 ensure_esp_mounted() {
     local esp_mount="" esp_dev="" candidate
 
-    esp_mount="$(findmnt -n -o TARGET /boot/efi 2>/dev/null || findmnt -n -o TARGET /efi 2>/dev/null || true)"
+    esp_mount="$(find_mounted_esp_target || true)"
     if [[ -n "$esp_mount" ]]; then
         info "ESP mounted at ${esp_mount}."
         return 0
@@ -88,7 +111,7 @@ ensure_esp_mounted() {
     warn "ESP not currently mounted. Attempting automatic mount..."
 
     # First try fstab-based mount by mount point.
-    for candidate in /boot/efi /efi; do
+    for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
         mkdir -p "$candidate"
         if mount "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
             info "Mounted ESP at ${candidate} using fstab entry."
@@ -99,16 +122,13 @@ ensure_esp_mounted() {
     # Fallback: detect the ESP partition and mount directly.
     esp_dev="$(find_esp_device || true)"
     if [[ -n "$esp_dev" ]]; then
-        if [[ -d /boot ]]; then
-            candidate="/boot/efi"
-        else
-            candidate="/efi"
-        fi
-        mkdir -p "$candidate"
-        if mount -t vfat "$esp_dev" "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
-            info "Mounted ESP device ${esp_dev} at ${candidate}."
-            return 0
-        fi
+        for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
+            mkdir -p "$candidate"
+            if mount -t vfat "$esp_dev" "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
+                info "Mounted ESP device ${esp_dev} at ${candidate}."
+                return 0
+            fi
+        done
     fi
 
     return 1
@@ -213,7 +233,7 @@ phase_preflight() {
         info "UEFI environment confirmed."
     fi
 
-    ensure_esp_mounted || die "ESP not mounted at /boot/efi or /efi and automatic mount failed. Mount it manually, then re-run."
+    ensure_esp_mounted || die "ESP is not mounted and automatic mount failed. Checked: ${ESP_MOUNT_CANDIDATES[*]}. Mount it manually, then re-run."
 }
 
 # =============================================================================
@@ -278,22 +298,45 @@ warn()  { echo -e "${YLW}[uki-build]${RST} $*" >&2; }
 die()   { echo -e "${RED}[uki-build]${RST} $*" >&2; exit 1; }
 require_cmd() { command -v "$1" &>/dev/null || die "Required command missing: $1"; }
 
+ESP_MOUNT_CANDIDATES=(
+    /boot/efi
+    /efi
+    /boot
+    /boot/EFI
+    /esp
+)
+
 find_esp_device() {
     lsblk -pnro PATH,PARTTYPE,FSTYPE 2>/dev/null \
         | awk '$2=="c12a7328-f81f-11d2-ba4b-00a0c93ec93b" && tolower($3) ~ /fat|vfat/ {print $1; exit}'
 }
 
+find_mounted_esp_target() {
+    local candidate target
+
+    for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
+        target=$(findmnt -n -o TARGET "$candidate" 2>/dev/null || true)
+        [[ -n "$target" ]] && { echo "$target"; return 0; }
+    done
+
+    while read -r target; do
+        [[ -n "$target" ]] && { echo "$target"; return 0; }
+    done < <(findmnt -rn -t vfat,fat -o TARGET 2>/dev/null | awk '$1 ~ /^\// && system("test -d " $1 "/EFI") == 0 {print $1}')
+
+    return 1
+}
+
 ensure_esp_mounted() {
     local esp_mount="" esp_dev="" candidate
 
-    esp_mount=$(findmnt -n -o TARGET /boot/efi 2>/dev/null || findmnt -n -o TARGET /efi 2>/dev/null || true)
+    esp_mount=$(find_mounted_esp_target || true)
     if [[ -n "$esp_mount" ]]; then
         info "ESP mounted at ${esp_mount}"
         return 0
     fi
 
     warn "ESP not mounted. Attempting automatic mount..."
-    for candidate in /boot/efi /efi; do
+    for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
         mkdir -p "$candidate"
         if mount "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
             info "Mounted ESP at ${candidate} using fstab entry"
@@ -303,13 +346,13 @@ ensure_esp_mounted() {
 
     esp_dev=$(find_esp_device || true)
     if [[ -n "$esp_dev" ]]; then
-        candidate="/boot/efi"
-        [[ -d /boot ]] || candidate="/efi"
-        mkdir -p "$candidate"
-        if mount -t vfat "$esp_dev" "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
-            info "Mounted ESP device ${esp_dev} at ${candidate}"
-            return 0
-        fi
+        for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
+            mkdir -p "$candidate"
+            if mount -t vfat "$esp_dev" "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
+                info "Mounted ESP device ${esp_dev} at ${candidate}"
+                return 0
+            fi
+        done
     fi
 
     return 1
@@ -326,7 +369,7 @@ require_cmd lsblk
 require_cmd efibootmgr
 [[ -f "$KERNEL_IMG" ]] || die "Kernel image not found: ${KERNEL_IMG}"
 mkdir -p "$EFI_DIR"
-ensure_esp_mounted || die "ESP is not mounted and automatic mount failed."
+ensure_esp_mounted || die "ESP is not mounted and automatic mount failed. Checked: ${ESP_MOUNT_CANDIDATES[*]}"
 
 # Build effective cmdline
 if [[ "$AUTO_DETECT_CMDLINE" -eq 1 ]]; then
@@ -373,7 +416,7 @@ info "UKI built successfully: ${UKI_OUT} ($(du -sh "$UKI_OUT" | cut -f1))"
 LABEL="Linux UKI ${KERNEL_VER}"
 
 # Determine ESP mount point, disk, and partition number
-ESP_MOUNT=$(findmnt -n -o TARGET /boot/efi 2>/dev/null || findmnt -n -o TARGET /efi 2>/dev/null) \
+ESP_MOUNT=$(find_mounted_esp_target) \
     || { warn "Cannot detect ESP mount — skipping efibootmgr."; exit 0; }
 ESP_DEV=$(findmnt -n -o SOURCE "$ESP_MOUNT") \
     || { warn "Cannot detect ESP device — skipping efibootmgr."; exit 0; }

--- a/uki-setup.sh
+++ b/uki-setup.sh
@@ -85,11 +85,18 @@ find_esp_device() {
 }
 
 find_mounted_esp_target() {
-    local candidate target
+    local candidate target fstype
 
     for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
         target="$(findmnt -n -o TARGET "$candidate" 2>/dev/null || true)"
-        [[ -n "$target" ]] && { echo "$target"; return 0; }
+        [[ -n "$target" ]] || continue
+
+        fstype="$(findmnt -n -o FSTYPE --target "$target" 2>/dev/null || true)"
+        [[ "$fstype" =~ ^(vfat|fat|msdos)$ ]] || continue
+        [[ -d "$target/EFI" ]] || continue
+
+        echo "$target"
+        return 0
     done
 
     while read -r target; do
@@ -312,11 +319,18 @@ find_esp_device() {
 }
 
 find_mounted_esp_target() {
-    local candidate target
+    local candidate target fstype
 
     for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
         target=$(findmnt -n -o TARGET "$candidate" 2>/dev/null || true)
-        [[ -n "$target" ]] && { echo "$target"; return 0; }
+        [[ -n "$target" ]] || continue
+
+        fstype=$(findmnt -n -o FSTYPE --target "$target" 2>/dev/null || true)
+        [[ "$fstype" =~ ^(vfat|fat|msdos)$ ]] || continue
+        [[ -d "$target/EFI" ]] || continue
+
+        echo "$target"
+        return 0
     done
 
     while read -r target; do


### PR DESCRIPTION
### Motivation

- Automatic ESP detection/mounting was failing on some Fedora systems where the ESP is not mounted at `/boot/efi` or `/efi`, leading to a hard failure during setup. 
- The goal is to make ESP discovery more robust by checking additional common mount points and scanning mounted FAT/VFAT filesystems for an `EFI` directory. 

### Description

- Add `ESP_MOUNT_CANDIDATES` containing `/boot/efi`, `/efi`, `/boot`, `/boot/EFI`, and `/esp` and iterate these when attempting fstab-based mounts. 
- Implement `find_mounted_esp_target()` which first checks the candidate mount points and then falls back to scanning `findmnt` for FAT/VFAT mounts that contain an `EFI` directory. 
- Replace direct `/boot/efi`/`/efi` lookups in `ensure_esp_mounted()` and the generated `uki-build.sh` template with the new detection and candidate-iteration logic, and attempt mounting the detected ESP device across all candidates. 
- Improve error messages to list the checked locations and update `README.md` to document the expanded ESP handling. 

### Testing

- Ran `bash -n uki-setup.sh` to verify there are no syntax errors; the check succeeded. 
- Ran the repository test script `bash tests/test_uki_setup.sh`, which verifies generation of the `uki-build.sh` helper and kernel-install plugin and it completed successfully. 
- End-to-end local checks in the test harness completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acdccc4b48832a873f90d36c197ad0)