### PR TITLE
Enable automatic UKI cmdline detection with GRUB fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ curl -fsSL https://raw.githubusercontent.com/GlitchSlayed/Fedora-UKI-Script/main
 ```
 
 1. Clone this repository.
-2. Edit configuration values at the top of `uki-setup.sh` (especially `CMDLINE`).
+2. Optionally review configuration values at the top of `uki-setup.sh` (`AUTO_DETECT_CMDLINE` is enabled by default, while `CMDLINE` remains a manual fallback).
 3. Run:
 
 ```bash
@@ -100,21 +100,27 @@ EFI_DIR="/boot/efi/EFI/Linux"
 ### `CMDLINE`
 Kernel command line embedded into the UKI.
 
-Default placeholder:
+Default fallback value:
 
 ```bash
-CMDLINE="rw quiet rhgb"
+CMDLINE="root=UUID=REPLACE-ME rw quiet rhgb"
 ```
 
-You should typically include your root device details (`root=UUID=...`, and any encryption/LVM/btrfs args needed by your setup).
+This is only used when auto-detection is disabled or cannot find a usable bootable cmdline. Set it to your own known-good manual value as a backup.
 
 ### `AUTO_DETECT_CMDLINE`
-When set to `1`, command line is derived from `/proc/cmdline` (with boot-loader-specific items removed).
+When set to `1`, command line is auto-detected in this order:
+
+1. `/proc/cmdline` (current running boot)
+2. `/etc/kernel/cmdline`
+3. `GRUB_CMDLINE_LINUX` from `/etc/default/grub` and `/etc/default/grub.d/*.cfg`
+
+If none of these provide a bootable command line (for example one containing `root=`), the script falls back to `CMDLINE`.
 
 Default:
 
 ```bash
-AUTO_DETECT_CMDLINE=0
+AUTO_DETECT_CMDLINE=1
 ```
 
 ### `EFI_STUB`

--- a/uki-setup.sh
+++ b/uki-setup.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 EFI_DIR="/boot/efi/EFI/Linux"
 
 # Kernel command-line embedded into the UKI.
-# !! EDIT THIS before running setup !!
+# This acts as a manual fallback if auto-detection cannot find a usable value.
 #
 # Find your root UUID with:  lsblk -f   or   blkid
 #
@@ -38,12 +38,15 @@ EFI_DIR="/boot/efi/EFI/Linux"
 #   LUKS full-disk encryption:
 #     CMDLINE="rd.luks.uuid=xxxx rd.lvm.lv=fedora/root root=/dev/mapper/fedora-root rw quiet rhgb"
 #
-CMDLINE="rw quiet rhgb"
+CMDLINE="root=UUID=REPLACE-ME rw quiet rhgb"
 
-# Set to 1 to auto-detect the cmdline from the currently running system
-# (reads /proc/cmdline, strips loader-specific tokens like BOOT_IMAGE=).
-# Useful when you are unsure of the exact parameters needed.
-AUTO_DETECT_CMDLINE=0
+# Set to 1 to auto-detect cmdline automatically.
+# Detection order:
+#   1) /proc/cmdline (current boot)
+#   2) /etc/kernel/cmdline
+#   3) GRUB_CMDLINE_LINUX from /etc/default/grub or /etc/default/grub.d/*.cfg
+# If all of the above fail, falls back to CMDLINE.
+AUTO_DETECT_CMDLINE=1
 
 # Path to the systemd-boot EFI stub used by dracut --uefi.
 # Fedora ships this in systemd-boot-unsigned or systemd.
@@ -69,6 +72,66 @@ warn()  { echo "${YLW}${BLD}[warn]${RST} $*" >&2; }
 die()   { echo "${RED}${BLD}[err]${RST}  $*" >&2; exit 1; }
 hr()    { echo "──────────────────────────────────────────────────────────────"; }
 require_cmd() { command -v "$1" &>/dev/null || die "Required command missing: $1"; }
+
+sanitize_cmdline() {
+    sed -E 's/(^| )BOOT_IMAGE=[^ ]*//g; s/(^| )initrd=[^ ]*//g; s/(^| )rd\.driver\.blacklist=[^ ]*//g; s/  +/ /g; s/^ //; s/ $//'
+}
+
+read_grub_cmdline() {
+    local file line value
+
+    for file in /etc/default/grub /etc/default/grub.d/*.cfg; do
+        [[ -f "$file" ]] || continue
+        while IFS= read -r line; do
+            [[ "$line" =~ ^[[:space:]]*# ]] && continue
+            if [[ "$line" =~ GRUB_CMDLINE_LINUX[[:space:]]*= ]]; then
+                value=$(printf '%s\n' "$line" | sed -n 's/^[[:space:]]*GRUB_CMDLINE_LINUX[[:space:]]*=[[:space:]]*"\\(.*\\)"[[:space:]]*$/\\1/p')
+                [[ -z "$value" ]] && value=$(printf '%s\n' "$line" | sed -n "s/^[[:space:]]*GRUB_CMDLINE_LINUX[[:space:]]*=[[:space:]]*'\\(.*\\)'[[:space:]]*$/\\1/p")
+                [[ -n "$value" ]] && { echo "$value"; return 0; }
+            fi
+        done < "$file"
+    done
+
+    return 1
+}
+
+get_effective_cmdline() {
+    local proc_cmdline kernel_cmdline grub_cmdline
+
+    if [[ "$AUTO_DETECT_CMDLINE" -eq 1 ]]; then
+        if [[ -r /proc/cmdline ]]; then
+            proc_cmdline=$(sanitize_cmdline < /proc/cmdline | xargs || true)
+            if [[ -n "$proc_cmdline" && "$proc_cmdline" =~ (root=|rd.luks.uuid=|rootfstype=) ]]; then
+                info "Using cmdline from /proc/cmdline"
+                echo "$proc_cmdline"
+                return 0
+            fi
+        fi
+
+        if [[ -s /etc/kernel/cmdline ]]; then
+            kernel_cmdline=$(sanitize_cmdline < /etc/kernel/cmdline | xargs || true)
+            if [[ -n "$kernel_cmdline" && "$kernel_cmdline" =~ (root=|rd.luks.uuid=|rootfstype=) ]]; then
+                info "Using cmdline from /etc/kernel/cmdline"
+                echo "$kernel_cmdline"
+                return 0
+            fi
+        fi
+
+        grub_cmdline=$(read_grub_cmdline || true)
+        if [[ -n "$grub_cmdline" ]]; then
+            grub_cmdline=$(printf '%s\n' "$grub_cmdline" | sanitize_cmdline | xargs || true)
+            if [[ -n "$grub_cmdline" && "$grub_cmdline" =~ (root=|rd.luks.uuid=|rootfstype=) ]]; then
+                info "Using cmdline from GRUB configuration"
+                echo "$grub_cmdline"
+                return 0
+            fi
+        fi
+
+        warn "Auto-detect enabled, but no bootable cmdline was detected. Falling back to configured CMDLINE."
+    fi
+
+    echo "$CMDLINE"
+}
 
 ESP_MOUNT_CANDIDATES=(
     /boot/efi
@@ -385,14 +448,69 @@ require_cmd efibootmgr
 mkdir -p "$EFI_DIR"
 ensure_esp_mounted || die "ESP is not mounted and automatic mount failed. Checked: ${ESP_MOUNT_CANDIDATES[*]}"
 
+sanitize_cmdline() {
+    sed -E 's/(^| )BOOT_IMAGE=[^ ]*//g; s/(^| )initrd=[^ ]*//g; s/(^| )rd\.driver\.blacklist=[^ ]*//g; s/  +/ /g; s/^ //; s/ $//'
+}
+
+read_grub_cmdline() {
+    local file line value
+
+    for file in /etc/default/grub /etc/default/grub.d/*.cfg; do
+        [[ -f "$file" ]] || continue
+        while IFS= read -r line; do
+            [[ "$line" =~ ^[[:space:]]*# ]] && continue
+            if [[ "$line" =~ GRUB_CMDLINE_LINUX[[:space:]]*= ]]; then
+                value=$(printf '%s\n' "$line" | sed -n 's/^[[:space:]]*GRUB_CMDLINE_LINUX[[:space:]]*=[[:space:]]*"\\(.*\\)"[[:space:]]*$/\\1/p')
+                [[ -z "$value" ]] && value=$(printf '%s\n' "$line" | sed -n "s/^[[:space:]]*GRUB_CMDLINE_LINUX[[:space:]]*=[[:space:]]*'\\(.*\\)'[[:space:]]*$/\\1/p")
+                [[ -n "$value" ]] && { echo "$value"; return 0; }
+            fi
+        done < "$file"
+    done
+
+    return 1
+}
+
+get_effective_cmdline() {
+    local proc_cmdline kernel_cmdline grub_cmdline
+
+    if [[ "$AUTO_DETECT_CMDLINE" -eq 1 ]]; then
+        if [[ -r /proc/cmdline ]]; then
+            proc_cmdline=$(sanitize_cmdline < /proc/cmdline | xargs || true)
+            if [[ -n "$proc_cmdline" && "$proc_cmdline" =~ (root=|rd.luks.uuid=|rootfstype=) ]]; then
+                info "Using cmdline from /proc/cmdline: ${proc_cmdline}"
+                echo "$proc_cmdline"
+                return 0
+            fi
+        fi
+
+        if [[ -s /etc/kernel/cmdline ]]; then
+            kernel_cmdline=$(sanitize_cmdline < /etc/kernel/cmdline | xargs || true)
+            if [[ -n "$kernel_cmdline" && "$kernel_cmdline" =~ (root=|rd.luks.uuid=|rootfstype=) ]]; then
+                info "Using cmdline from /etc/kernel/cmdline: ${kernel_cmdline}"
+                echo "$kernel_cmdline"
+                return 0
+            fi
+        fi
+
+        grub_cmdline=$(read_grub_cmdline || true)
+        if [[ -n "$grub_cmdline" ]]; then
+            grub_cmdline=$(printf '%s\n' "$grub_cmdline" | sanitize_cmdline | xargs || true)
+            if [[ -n "$grub_cmdline" && "$grub_cmdline" =~ (root=|rd.luks.uuid=|rootfstype=) ]]; then
+                info "Using cmdline from GRUB configuration: ${grub_cmdline}"
+                echo "$grub_cmdline"
+                return 0
+            fi
+        fi
+
+        warn "Auto-detect enabled, but no bootable cmdline was detected. Falling back to configured CMDLINE: ${CMDLINE}"
+    fi
+
+    info "Using configured cmdline: ${CMDLINE}"
+    echo "$CMDLINE"
+}
+
 # Build effective cmdline
-if [[ "$AUTO_DETECT_CMDLINE" -eq 1 ]]; then
-    EFFECTIVE_CMDLINE=$(sed 's/BOOT_IMAGE=[^ ]*//g; s/initrd=[^ ]*//g; s/  */ /g' /proc/cmdline | xargs)
-    info "Auto-detected cmdline: ${EFFECTIVE_CMDLINE}"
-else
-    EFFECTIVE_CMDLINE="$CMDLINE"
-    info "Using configured cmdline: ${EFFECTIVE_CMDLINE}"
-fi
+EFFECTIVE_CMDLINE=$(get_effective_cmdline)
 
 # Locate EFI stub
 if [[ -z "$EFI_STUB" ]]; then
@@ -580,15 +698,13 @@ phase_initial_build() {
     hr
     info "Phase 6: Building UKI for current kernel: $(uname -r)"
 
-    if [[ "$AUTO_DETECT_CMDLINE" -eq 0 && "$CMDLINE" == "rw quiet rhgb" ]]; then
+    if [[ "$AUTO_DETECT_CMDLINE" -eq 0 && "$CMDLINE" == "root=UUID=REPLACE-ME rw quiet rhgb" ]]; then
         warn "────────────────────────────────────────────────────────────"
-        warn "CMDLINE is still the placeholder default."
-        warn "The UKI may not boot correctly without a proper root= parameter."
-        warn "Edit CMDLINE at the top of this script, then re-run, OR"
-        warn "set AUTO_DETECT_CMDLINE=1 to pull parameters from the live system."
+        warn "AUTO_DETECT_CMDLINE is disabled and CMDLINE is still placeholder text."
+        warn "Set CMDLINE to a real root=... value, or enable AUTO_DETECT_CMDLINE=1."
         warn "────────────────────────────────────────────────────────────"
-        read -r -p "Continue with default CMDLINE anyway? [y/N] " ans
-        [[ "${ans,,}" == "y" ]] || { info "Aborted. Edit CMDLINE and re-run."; exit 0; }
+        read -r -p "Continue with placeholder CMDLINE anyway? [y/N] " ans
+        [[ "${ans,,}" == "y" ]] || { info "Aborted. Set CMDLINE and re-run."; exit 0; }
     fi
 
     "$BUILD_SCRIPT" "$(uname -r)"


### PR DESCRIPTION
### Motivation

- Make the setup usable out-of-the-box by auto-detecting a bootable kernel cmdline instead of requiring manual `CMDLINE` edits before first run.
- Recover relevant boot parameters from existing system state or legacy GRUB configuration when the running environment can provide them.
- Keep a manual `CMDLINE` as a safe fallback and only prompt the user when autodetection is intentionally disabled and the placeholder remains.

### Description

- Default `AUTO_DETECT_CMDLINE` is now `1` and `CMDLINE` was changed to a clear fallback placeholder `root=UUID=REPLACE-ME rw quiet rhgb`.
- Added `sanitize_cmdline`, `read_grub_cmdline`, and `get_effective_cmdline` logic that resolve the kernel cmdline in order from `/proc/cmdline`, `/etc/kernel/cmdline`, and `GRUB_CMDLINE_LINUX` in `/etc/default/grub` or `/etc/default/grub.d/*.cfg`, then fall back to `CMDLINE` if nothing bootable is found, and this is used when building the UKI.
- The same detection/fallback behavior is injected into the generated `/usr/local/sbin/uki-build.sh` template so automated kernel-install hooks reuse the same resolution logic.
- Updated the Phase 6 prompt to only warn when autodetect is disabled and the `CMDLINE` placeholder remains, and updated `README.md` to document the new defaults and detection order.

### Testing

- Ran `bash -n uki-setup.sh tests/test_uki_setup.sh` with no syntax errors reported.
- Ran `bash tests/test_uki_setup.sh` and the repository test suite completed successfully.
- Attempted `shellcheck -P . uki-setup.sh tests/test_uki_setup.sh` but `shellcheck` was not available in the environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace0a3628c832aba3a00dfc86fe37a)