### PR TITLE
Fix ESP detection after automatic mount

### DIFF
--- a/uki-setup.sh
+++ b/uki-setup.sh
@@ -184,8 +184,11 @@ ensure_esp_mounted() {
     for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
         mkdir -p "$candidate"
         if mount "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
-            info "Mounted ESP at ${candidate} using fstab entry."
-            return 0
+            esp_mount="$(find_mounted_esp_target || true)"
+            if [[ -n "$esp_mount" ]]; then
+                info "Mounted ESP at ${esp_mount} using fstab entry."
+                return 0
+            fi
         fi
     done
 
@@ -195,8 +198,11 @@ ensure_esp_mounted() {
         for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
             mkdir -p "$candidate"
             if mount -t vfat "$esp_dev" "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
-                info "Mounted ESP device ${esp_dev} at ${candidate}."
-                return 0
+                esp_mount="$(find_mounted_esp_target || true)"
+                if [[ -n "$esp_mount" ]]; then
+                    info "Mounted ESP device ${esp_dev} at ${esp_mount}."
+                    return 0
+                fi
             fi
         done
     fi
@@ -416,8 +422,11 @@ ensure_esp_mounted() {
     for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
         mkdir -p "$candidate"
         if mount "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
-            info "Mounted ESP at ${candidate} using fstab entry"
-            return 0
+            esp_mount=$(find_mounted_esp_target || true)
+            if [[ -n "$esp_mount" ]]; then
+                info "Mounted ESP at ${esp_mount} using fstab entry"
+                return 0
+            fi
         fi
     done
 
@@ -426,8 +435,11 @@ ensure_esp_mounted() {
         for candidate in "${ESP_MOUNT_CANDIDATES[@]}"; do
             mkdir -p "$candidate"
             if mount -t vfat "$esp_dev" "$candidate" &>/dev/null && findmnt "$candidate" &>/dev/null; then
-                info "Mounted ESP device ${esp_dev} at ${candidate}"
-                return 0
+                esp_mount=$(find_mounted_esp_target || true)
+                if [[ -n "$esp_mount" ]]; then
+                    info "Mounted ESP device ${esp_dev} at ${esp_mount}"
+                    return 0
+                fi
             fi
         done
     fi


### PR DESCRIPTION
### Motivation
- The setup could report a successful automatic mount even when the mounted path was not a valid ESP, which later caused `efibootmgr` registration to be skipped with messages like `Cannot detect ESP mount — skipping efibootmgr.`
- The goal is to ensure that automatic mount attempts only succeed when a verified ESP (vfat + `EFI/` present) is detectable afterward.
- This avoids false-positive mount success paths that lead to missing UEFI boot entry registration.

### Description
- After each automatic `mount` attempt the code now re-runs `find_mounted_esp_target` and only returns success when that function yields a non-empty validated ESP path, and log messages report the resolved `esp_mount` instead of the raw candidate.
- The change was applied in both the main `ensure_esp_mounted()` implementation and the generated `uki-build.sh` template written by `phase_write_build_script` so runtime and generated rebuild script behave consistently.
- Modified file: `uki-setup.sh` (updates to ESP validation logic and log messages).

### Testing
- Ran the repository test script with `bash tests/test_uki_setup.sh` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace4139190832a918f2efad6598e4c)