### PR TITLE
Add one-time (BootNext) workflow: `--boot-once`, `confirm`, EFI parsing and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Usage](#usage)
+- [Safer First Boot Workflow](#safer-first-boot-workflow)
 - [Example Workflow](#example-workflow)
 - [⚠️ Backups & Recovery](#%EF%B8%8F-backups--recovery)
 - [⚠️ Warnings & Known Failure Modes](#%EF%B8%8F-warnings--known-failure-modes)
@@ -203,8 +204,11 @@ Output is written atomically (temp file → rename) to prevent partial writes fr
 ```bash
 sudo rustyuki generate
 sudo rustyuki generate --kernel-version "$(uname -r)"
+sudo rustyuki generate --boot-once
 sudo rustyuki generate --dry-run   # preview only
 ```
+
+Use `--boot-once` when you want firmware to trial the new UKI exactly once via `efibootmgr --bootnext` before you make it permanent with `rustyuki confirm`.
 
 #### `install` — Generate and sync the ESP
 
@@ -215,12 +219,26 @@ sudo rustyuki install
 sudo rustyuki install --kernel-version "6.12.0-200.fc41.x86_64"
 ```
 
+Add `--boot-once` to schedule the new EFI entry as the next boot only via `efibootmgr --bootnext`, leaving your permanent `BootOrder` unchanged until you confirm the trial boot succeeded. The same flag is available on `generate` if you only want to register the UKI entry without running `bootctl update`.
+
+```bash
+sudo rustyuki install --boot-once
+```
+
 #### `reconcile` — Rebuild all installed kernel UKIs and prune stale artifacts
 
 Rebuilds UKIs for every kernel reported by `rpm -q kernel`, prunes stale `linux-*.efi` entries in the output directory, and runs `bootctl update`.
 
 ```bash
 sudo rustyuki reconcile
+```
+
+#### `confirm` — Make a successful trial boot permanent
+
+After booting the one-time UKI successfully, run `confirm` from that booted system. RustyUKI reads `BootCurrent` and moves that entry to the front of `BootOrder`, making the tested UKI your permanent default.
+
+```bash
+sudo rustyuki confirm
 ```
 
 #### `install-hook` — Run reconcile automatically on kernel updates
@@ -232,6 +250,23 @@ sudo rustyuki install-hook
 ```
 
 ---
+
+## Safer First Boot Workflow
+
+For first-time GRUB replacement or any risky UKI change, prefer a one-time boot trial instead of immediately changing your permanent firmware boot order.
+
+```bash
+# Build the UKI, refresh the ESP, and schedule it for the next boot only
+sudo rustyuki install --boot-once
+
+# Reboot normally; firmware will use BootNext exactly once
+sudo reboot
+
+# If the system came back successfully from the UKI, make it permanent
+sudo rustyuki confirm
+```
+
+This workflow keeps your existing default entry in `BootOrder` as the fallback if the trial boot fails, while still letting you verify the UKI end-to-end before committing to it.
 
 ## Example Workflow
 
@@ -245,11 +280,14 @@ sudo rustyuki status
 # Step 2 — dry run: see every command that will execute, without running anything
 sudo rustyuki generate --dry-run
 
-# Step 3 — build and install the UKI
-sudo rustyuki install
+# Step 3 — build and schedule a one-time trial boot
+sudo rustyuki install --boot-once
 
-# Step 4 — use your firmware's one-time boot menu (F12 / F2) to select the UKI entry
-#           DO NOT change your default boot order until you confirm it boots correctly
+# Step 4 — reboot normally and let BootNext test the UKI once
+sudo reboot
+
+# Step 5 — after a successful UKI boot, make it permanent
+sudo rustyuki confirm
 ```
 
 After booting into the UKI, verify it was used:

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,9 @@ use crate::cli::GenerateArgs;
 use crate::cmd::CommandRunner;
 use crate::config::AppConfig;
 use crate::dracut::build_initramfs;
-use crate::efi::{register_boot_entry, validate_esp_mount};
+use crate::efi::{
+    promote_current_boot_entry, register_boot_entry, schedule_one_time_boot, validate_esp_mount,
+};
 use crate::kernel::{
     list_installed_kernels, prune_stale_uki_artifacts, resolve_cmdline, CmdlineSettings,
 };
@@ -75,7 +77,8 @@ pub fn generate(
     runner: &dyn CommandRunner,
     cfg: &AppConfig,
     settings: &GenerateSettings,
-) -> Result<PathBuf> {
+    boot_once: bool,
+) -> Result<(PathBuf, String)> {
     validate_esp_mount(&settings.esp_path)?;
     ensure_required_paths(settings)?;
 
@@ -124,10 +127,19 @@ pub fn generate(
     let built_uki = build_uki(runner, &params)?;
 
     let label = format!("Linux UKI {}", settings.kernel_version);
-    register_boot_entry(runner, &settings.esp_path, &built_uki, &label)?;
+    let boot_num = register_boot_entry(runner, &settings.esp_path, &built_uki, &label)?;
 
-    info!("UKI generation finished: {}", built_uki.display());
-    Ok(built_uki)
+    if boot_once {
+        schedule_one_time_boot(runner, &boot_num)?;
+        info!("Scheduled BootNext for Boot{boot_num}; run `rustyuki confirm` after a successful trial boot to make it permanent");
+    }
+
+    info!(
+        "UKI generation finished: {} (Boot{})",
+        built_uki.display(),
+        boot_num
+    );
+    Ok((built_uki, boot_num))
 }
 
 /// Performs install flow: generate UKI, then execute bootloader maintenance.
@@ -135,8 +147,9 @@ pub fn install(
     runner: &dyn CommandRunner,
     cfg: &AppConfig,
     settings: &GenerateSettings,
+    boot_once: bool,
 ) -> Result<PathBuf> {
-    let path = generate(runner, cfg, settings)?;
+    let (path, _boot_num) = generate(runner, cfg, settings, boot_once)?;
 
     let installed = list_installed_kernels(runner)?;
     let removed = prune_stale_uki_artifacts(&settings.output_dir, &installed)?;
@@ -148,6 +161,7 @@ pub fn install(
     runner
         .run("bootctl", &["update"])
         .context("bootctl update failed")?;
+
     Ok(path)
 }
 
@@ -161,7 +175,7 @@ pub fn reconcile(
     for kernel in &kernels {
         let mut settings = base.clone();
         settings.kernel_version = kernel.clone();
-        let _ = generate(runner, cfg, &settings)?;
+        let _ = generate(runner, cfg, &settings, false)?;
     }
 
     let removed = prune_stale_uki_artifacts(&base.output_dir, &kernels)?;
@@ -174,6 +188,13 @@ pub fn reconcile(
         .context("bootctl update failed")?;
 
     Ok(())
+}
+
+/// Promotes the currently booted EFI entry to the front of BootOrder.
+pub fn confirm(runner: &dyn CommandRunner) -> Result<String> {
+    let boot_num = promote_current_boot_entry(runner)?;
+    info!("Confirmed Boot{boot_num} as the permanent default boot entry");
+    Ok(boot_num)
 }
 
 /// Reports current status and resolved paths.
@@ -229,6 +250,7 @@ mod tests {
             cmdline_file: None,
             splash: None,
             os_release: None,
+            boot_once: false,
         };
 
         let resolved = resolve_generate_settings(&cfg, &args, "6.9.0-test");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, Parser, Subcommand};
+use clap::{ArgAction, Args, Parser, Subcommand};
 use std::path::PathBuf;
 
 /// RustyUKI command-line interface.
@@ -34,10 +34,12 @@ pub enum Commands {
     InstallHook(InstallHookArgs),
     /// Show current operational status and resolved settings.
     Status,
+    /// Make the currently booted trial UKI the permanent default boot entry.
+    Confirm,
 }
 
 /// Shared override arguments for generation actions.
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Clone, Args)]
 pub struct GenerateArgs {
     /// Kernel version override.
     #[arg(long)]
@@ -57,6 +59,9 @@ pub struct GenerateArgs {
     /// Optional os-release path override.
     #[arg(long)]
     pub os_release: Option<PathBuf>,
+    /// Set the new EFI entry as the one-time next boot target instead of immediately changing permanent boot order.
+    #[arg(long)]
+    pub boot_once: bool,
 }
 
 /// Options for installing the kernel-install hook.

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -1,7 +1,22 @@
 use crate::cmd::CommandRunner;
 use anyhow::{bail, Context, Result};
 use log::info;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootEntry {
+    pub num: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BootState {
+    pub current: Option<String>,
+    pub next: Option<String>,
+    pub order: Vec<String>,
+    pub entries: Vec<BootEntry>,
+}
 
 /// Validates that ESP mountpoint exists.
 pub fn validate_esp_mount(esp_path: &Path) -> Result<()> {
@@ -14,13 +29,13 @@ pub fn validate_esp_mount(esp_path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Registers EFI boot entry for generated UKI.
+/// Registers EFI boot entry for generated UKI and returns the created boot number.
 pub fn register_boot_entry(
     runner: &dyn CommandRunner,
     esp_path: &Path,
     uki_path: &Path,
     label: &str,
-) -> Result<()> {
+) -> Result<String> {
     let esp_str = esp_path
         .to_str()
         .with_context(|| format!("non-UTF8 esp path {}", esp_path.display()))?;
@@ -50,17 +65,19 @@ pub fn register_boot_entry(
         bail!("failed to resolve parent disk for {source}");
     }
 
-    let dev_name = Path::new(&source)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .with_context(|| format!("invalid source device path {source}"))?;
-
-    let part_num = std::fs::read_to_string(format!("/sys/class/block/{dev_name}/partition"))
-        .with_context(|| format!("failed reading partition number for {dev_name}"))?
+    let part_num = runner
+        .run("lsblk", &["-no", "PARTNUM", &source])
+        .context("failed determining ESP partition number")?
+        .stdout
         .trim()
         .to_string();
 
+    if part_num.is_empty() {
+        bail!("failed to resolve partition number for {source}");
+    }
+
     let relative = make_efi_loader_path(esp_path, uki_path)?;
+    let before = query_boot_state(runner).ok();
 
     info!("Registering EFI entry label={label}, loader={relative}");
     runner.run(
@@ -79,7 +96,140 @@ pub fn register_boot_entry(
         ],
     )?;
 
+    let after = query_boot_state(runner).context("failed reading EFI boot entries after create")?;
+    detect_new_entry_number(before.as_ref(), &after, label)
+}
+
+pub fn query_boot_state(runner: &dyn CommandRunner) -> Result<BootState> {
+    let output = runner
+        .run("efibootmgr", &["--verbose"])
+        .context("failed querying EFI boot manager state")?;
+    parse_boot_state(&output.stdout)
+}
+
+pub fn schedule_one_time_boot(runner: &dyn CommandRunner, boot_num: &str) -> Result<()> {
+    info!("Scheduling one-time boot via BootNext={boot_num}");
+    runner
+        .run("efibootmgr", &["--bootnext", boot_num])
+        .with_context(|| format!("failed setting BootNext to {boot_num}"))?;
     Ok(())
+}
+
+pub fn promote_current_boot_entry(runner: &dyn CommandRunner) -> Result<String> {
+    let state = query_boot_state(runner)?;
+    let current = state.current.clone().context(
+        "firmware did not report BootCurrent; boot into the trial UKI first, then run `rustyuki confirm`",
+    )?;
+
+    if !state.entries.iter().any(|entry| entry.num == current) {
+        bail!("BootCurrent {current} is not present in efibootmgr output");
+    }
+
+    let mut boot_order = Vec::with_capacity(state.order.len().saturating_add(1));
+    boot_order.push(current.clone());
+    for entry in &state.order {
+        if entry != &current {
+            boot_order.push(entry.clone());
+        }
+    }
+
+    let boot_order_arg = boot_order.join(",");
+    info!("Promoting current boot entry {current} to the front of BootOrder");
+    runner
+        .run("efibootmgr", &["--bootorder", &boot_order_arg])
+        .with_context(|| format!("failed setting BootOrder to {boot_order_arg}"))?;
+    Ok(current)
+}
+
+fn detect_new_entry_number(
+    before: Option<&BootState>,
+    after: &BootState,
+    label: &str,
+) -> Result<String> {
+    let prior: HashSet<&str> = before
+        .map(|state| {
+            state
+                .entries
+                .iter()
+                .map(|entry| entry.num.as_str())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut created = after
+        .entries
+        .iter()
+        .filter(|entry| entry.label == label && !prior.contains(entry.num.as_str()));
+
+    if let Some(entry) = created.next() {
+        if created.next().is_none() {
+            return Ok(entry.num.clone());
+        }
+    }
+
+    let matching: Vec<&BootEntry> = after
+        .entries
+        .iter()
+        .filter(|entry| entry.label == label)
+        .collect();
+    if matching.len() == 1 {
+        return Ok(matching[0].num.clone());
+    }
+
+    bail!("failed to determine EFI boot number for newly created entry `{label}`")
+}
+
+fn parse_boot_state(text: &str) -> Result<BootState> {
+    let mut state = BootState::default();
+
+    for line in text.lines() {
+        if let Some(value) = line.strip_prefix("BootCurrent: ") {
+            state.current = Some(value.trim().to_string());
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("BootNext: ") {
+            let value = value.trim();
+            if !value.is_empty() {
+                state.next = Some(value.to_string());
+            }
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("BootOrder: ") {
+            state.order = value
+                .split(',')
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(ToOwned::to_owned)
+                .collect();
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("Boot") {
+            let Some((num, remainder)) = rest.split_once('*') else {
+                continue;
+            };
+            let num = num.trim();
+            if num.len() != 4 || !num.chars().all(|c| c.is_ascii_hexdigit()) {
+                continue;
+            }
+            let label = remainder
+                .split('\t')
+                .next()
+                .map(str::trim)
+                .unwrap_or_default();
+            if !label.is_empty() {
+                state.entries.push(BootEntry {
+                    num: num.to_string(),
+                    label: label.to_string(),
+                });
+            }
+        }
+    }
+
+    if state.entries.is_empty() {
+        bail!("no EFI boot entries found in efibootmgr output");
+    }
+
+    Ok(state)
 }
 
 /// Converts absolute UKI path under ESP into EFI loader path using backslashes.
@@ -97,7 +247,9 @@ pub fn make_efi_loader_path(esp_path: &Path, uki_path: &Path) -> Result<String> 
 
 #[cfg(test)]
 mod tests {
-    use super::make_efi_loader_path;
+    use super::{
+        detect_new_entry_number, make_efi_loader_path, parse_boot_state, BootEntry, BootState,
+    };
     use std::path::Path;
 
     #[test]
@@ -109,5 +261,51 @@ mod tests {
         .unwrap_or_else(|e| panic!("{e}"));
 
         assert_eq!(loader, "\\EFI\\Linux\\linux-6.8.efi");
+    }
+
+    #[test]
+    fn parse_boot_state_extracts_current_next_order_and_entries() {
+        let parsed = parse_boot_state(
+            "BootCurrent: 0003\nBootNext: 0007\nBootOrder: 0003,0001,0007\nBoot0001* Fedora\tHD(...)\nBoot0007* Linux UKI 6.11.4\tHD(...)\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(parsed.current.as_deref(), Some("0003"));
+        assert_eq!(parsed.next.as_deref(), Some("0007"));
+        assert_eq!(parsed.order, vec!["0003", "0001", "0007"]);
+        assert_eq!(parsed.entries.len(), 2);
+        assert_eq!(parsed.entries[1].label, "Linux UKI 6.11.4");
+    }
+
+    #[test]
+    fn detect_new_entry_prefers_bootnum_not_seen_before() {
+        let before = BootState {
+            current: Some("0001".to_string()),
+            next: None,
+            order: vec!["0001".to_string()],
+            entries: vec![BootEntry {
+                num: "0001".to_string(),
+                label: "Fedora".to_string(),
+            }],
+        };
+        let after = BootState {
+            current: Some("0001".to_string()),
+            next: None,
+            order: vec!["0001".to_string(), "0007".to_string()],
+            entries: vec![
+                BootEntry {
+                    num: "0001".to_string(),
+                    label: "Fedora".to_string(),
+                },
+                BootEntry {
+                    num: "0007".to_string(),
+                    label: "Linux UKI 6.11.4".to_string(),
+                },
+            ],
+        };
+
+        let boot_num = detect_new_entry_number(Some(&before), &after, "Linux UKI 6.11.4")
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(boot_num, "0007");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod privilege;
 mod ukify;
 
 use anyhow::{Context, Result};
-use app::{generate, install, reconcile, resolve_generate_settings, status};
+use app::{confirm, generate, install, reconcile, resolve_generate_settings, status};
 use clap::Parser;
 use cli::{Cli, Commands};
 use cmd::{CommandRunner, RealCommandRunner};
@@ -55,12 +55,12 @@ fn run() -> Result<()> {
         Commands::Generate(args) => {
             let uname = current_kernel(&runner)?;
             let settings = resolve_generate_settings(&cfg, args, &uname);
-            let _ = generate(&runner, &cfg, &settings)?;
+            let _ = generate(&runner, &cfg, &settings, args.boot_once)?;
         }
         Commands::Install(args) => {
             let uname = current_kernel(&runner)?;
             let settings = resolve_generate_settings(&cfg, args, &uname);
-            let _ = install(&runner, &cfg, &settings)?;
+            let _ = install(&runner, &cfg, &settings, args.boot_once)?;
         }
         Commands::Reconcile => {
             let uname = current_kernel(&runner)?;
@@ -73,6 +73,7 @@ fn run() -> Result<()> {
                     cmdline_file: None,
                     splash: None,
                     os_release: None,
+                    boot_once: false,
                 },
                 "",
             );
@@ -92,6 +93,10 @@ fn run() -> Result<()> {
         Commands::Status => {
             let text = status(&runner, &cfg)?;
             println!("{text}");
+        }
+        Commands::Confirm => {
+            let boot_num = confirm(&runner)?;
+            println!("confirmed Boot{boot_num} as the permanent default boot entry");
         }
     }
 

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -24,7 +24,7 @@ mod kernel;
 #[path = "../src/ukify.rs"]
 mod ukify;
 
-use app::{resolve_generate_settings, status};
+use app::{confirm, generate, install, resolve_generate_settings, status, GenerateSettings};
 use cli::GenerateArgs;
 use cmd::{CommandRunner, ProcessOutput};
 use config::AppConfig;
@@ -95,6 +95,7 @@ fn default_args() -> GenerateArgs {
         cmdline_file: None,
         splash: None,
         os_release: None,
+        boot_once: false,
     }
 }
 
@@ -108,6 +109,7 @@ fn resolve_settings_cli_override_wins() {
         cmdline_file: Some("/override/cmdline".into()),
         splash: Some("/override/splash.bmp".into()),
         os_release: Some("/override/os-release".into()),
+        boot_once: false,
     };
 
     let resolved = resolve_generate_settings(&cfg, &args, "ignored");
@@ -375,4 +377,373 @@ fn prune_removes_only_unknown_kernel_efis() {
     assert!(keep.exists());
     assert!(!prune.exists());
     assert!(other.exists());
+}
+
+#[test]
+fn generate_with_boot_once_sets_bootnext_immediately() {
+    let temp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+    let esp = temp.path().join("esp");
+    let out = esp.join("EFI/Linux");
+    let cmdline = temp.path().join("cmdline");
+    let os_release = temp.path().join("os-release");
+    std::fs::create_dir_all(&out).unwrap_or_else(|e| panic!("{e}"));
+    std::fs::write(&cmdline, "root=UUID=test rw quiet").unwrap_or_else(|e| panic!("{e}"));
+    std::fs::write(
+        &os_release,
+        "NAME=TestOS
+",
+    )
+    .unwrap_or_else(|e| panic!("{e}"));
+
+    let kernel_dir = PathBuf::from("/lib/modules/6.11.5-test");
+    std::fs::create_dir_all(&kernel_dir).unwrap_or_else(|e| panic!("{e}"));
+    std::fs::write(kernel_dir.join("vmlinuz"), b"kernel").unwrap_or_else(|e| panic!("{e}"));
+
+    let expected_temp_out = out.join(".linux-6.11.5-test.efi.tmp");
+    let final_out = out.join("linux-6.11.5-test.efi");
+
+    let runner = MockRunner::new(vec![
+        ExpectedCall {
+            program: "dracut".to_string(),
+            args: vec![
+                "-f".to_string(),
+                "/tmp/initramfs-6.11.5-test.img".to_string(),
+                "6.11.5-test".to_string(),
+            ],
+            output: Ok(ProcessOutput::default()),
+        },
+        ExpectedCall {
+            program: "ukify".to_string(),
+            args: vec![
+                "build".to_string(),
+                "--linux".to_string(),
+                kernel_dir.join("vmlinuz").display().to_string(),
+                "--initrd".to_string(),
+                "/tmp/initramfs-6.11.5-test.img".to_string(),
+                "--cmdline".to_string(),
+                "root=/dev/test rw quiet".to_string(),
+                "--os-release".to_string(),
+                os_release.display().to_string(),
+                "--output".to_string(),
+                expected_temp_out.display().to_string(),
+            ],
+            output: Ok(ProcessOutput::default()),
+        },
+        ExpectedCall {
+            program: "findmnt".to_string(),
+            args: vec![
+                "-n".to_string(),
+                "-o".to_string(),
+                "SOURCE".to_string(),
+                esp.display().to_string(),
+            ],
+            output: Ok(ProcessOutput {
+                stdout: "/dev/nvme0n1p1
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "lsblk".to_string(),
+            args: vec![
+                "-no".to_string(),
+                "PKNAME".to_string(),
+                "/dev/nvme0n1p1".to_string(),
+            ],
+            output: Ok(ProcessOutput {
+                stdout: "nvme0n1
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "lsblk".to_string(),
+            args: vec![
+                "-no".to_string(),
+                "PARTNUM".to_string(),
+                "/dev/nvme0n1p1".to_string(),
+            ],
+            output: Ok(ProcessOutput {
+                stdout: "1
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec!["--verbose".to_string()],
+            output: Ok(ProcessOutput {
+                stdout: "BootCurrent: 0001
+BootOrder: 0001
+Boot0001* Fedora	HD(...)
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec![
+                "--quiet".to_string(),
+                "--create".to_string(),
+                "--disk".to_string(),
+                "/dev/nvme0n1".to_string(),
+                "--part".to_string(),
+                "1".to_string(),
+                "--label".to_string(),
+                "Linux UKI 6.11.5-test".to_string(),
+                "--loader".to_string(),
+                r"\EFI\Linux\linux-6.11.5-test.efi".to_string(),
+            ],
+            output: Ok(ProcessOutput::default()),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec!["--verbose".to_string()],
+            output: Ok(ProcessOutput {
+                stdout: "BootCurrent: 0001
+BootOrder: 0001,0008
+Boot0001* Fedora	HD(...)
+Boot0008* Linux UKI 6.11.5-test	HD(...)
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec!["--bootnext".to_string(), "0008".to_string()],
+            output: Ok(ProcessOutput::default()),
+        },
+    ]);
+
+    let mut cfg = AppConfig::default();
+    cfg.uki.auto_detect_cmdline = false;
+    cfg.uki.configured_cmdline = "root=/dev/test rw quiet".to_string();
+    let settings = GenerateSettings {
+        kernel_version: "6.11.5-test".to_string(),
+        esp_path: esp.clone(),
+        output_dir: out.clone(),
+        cmdline_file: cmdline,
+        splash: None,
+        os_release,
+    };
+
+    let (built, boot_num) =
+        generate(&runner, &cfg, &settings, true).unwrap_or_else(|e| panic!("{e:#}"));
+    assert_eq!(built, final_out);
+    assert_eq!(boot_num, "0008");
+    runner.assert_no_pending();
+
+    std::fs::remove_file(kernel_dir.join("vmlinuz")).ok();
+    std::fs::remove_dir(kernel_dir).ok();
+}
+
+#[test]
+fn install_with_boot_once_sets_bootnext_after_bootctl_update() {
+    let temp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+    let esp = temp.path().join("esp");
+    let out = esp.join("EFI/Linux");
+    let cmdline = temp.path().join("cmdline");
+    let os_release = temp.path().join("os-release");
+    std::fs::create_dir_all(&out).unwrap_or_else(|e| panic!("{e}"));
+    std::fs::write(&cmdline, "root=UUID=test rw quiet").unwrap_or_else(|e| panic!("{e}"));
+    std::fs::write(
+        &os_release,
+        "NAME=TestOS
+",
+    )
+    .unwrap_or_else(|e| panic!("{e}"));
+
+    let kernel_dir = PathBuf::from("/lib/modules/6.11.4-test");
+    std::fs::create_dir_all(&kernel_dir).unwrap_or_else(|e| panic!("{e}"));
+    std::fs::write(kernel_dir.join("vmlinuz"), b"kernel").unwrap_or_else(|e| panic!("{e}"));
+
+    let expected_temp_out = out.join(".linux-6.11.4-test.efi.tmp");
+    let final_out = out.join("linux-6.11.4-test.efi");
+
+    let runner = MockRunner::new(vec![
+        ExpectedCall {
+            program: "dracut".to_string(),
+            args: vec![
+                "-f".to_string(),
+                "/tmp/initramfs-6.11.4-test.img".to_string(),
+                "6.11.4-test".to_string(),
+            ],
+            output: Ok(ProcessOutput::default()),
+        },
+        ExpectedCall {
+            program: "ukify".to_string(),
+            args: vec![
+                "build".to_string(),
+                "--linux".to_string(),
+                kernel_dir.join("vmlinuz").display().to_string(),
+                "--initrd".to_string(),
+                "/tmp/initramfs-6.11.4-test.img".to_string(),
+                "--cmdline".to_string(),
+                "root=/dev/test rw quiet".to_string(),
+                "--os-release".to_string(),
+                os_release.display().to_string(),
+                "--output".to_string(),
+                expected_temp_out.display().to_string(),
+            ],
+            output: Ok(ProcessOutput::default()),
+        },
+        ExpectedCall {
+            program: "findmnt".to_string(),
+            args: vec![
+                "-n".to_string(),
+                "-o".to_string(),
+                "SOURCE".to_string(),
+                esp.display().to_string(),
+            ],
+            output: Ok(ProcessOutput {
+                stdout: "/dev/nvme0n1p1
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "lsblk".to_string(),
+            args: vec![
+                "-no".to_string(),
+                "PKNAME".to_string(),
+                "/dev/nvme0n1p1".to_string(),
+            ],
+            output: Ok(ProcessOutput {
+                stdout: "nvme0n1
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "lsblk".to_string(),
+            args: vec![
+                "-no".to_string(),
+                "PARTNUM".to_string(),
+                "/dev/nvme0n1p1".to_string(),
+            ],
+            output: Ok(ProcessOutput {
+                stdout: "1
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec!["--verbose".to_string()],
+            output: Ok(ProcessOutput {
+                stdout: "BootCurrent: 0001
+BootOrder: 0001
+Boot0001* Fedora	HD(...)
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec![
+                "--quiet".to_string(),
+                "--create".to_string(),
+                "--disk".to_string(),
+                "/dev/nvme0n1".to_string(),
+                "--part".to_string(),
+                "1".to_string(),
+                "--label".to_string(),
+                "Linux UKI 6.11.4-test".to_string(),
+                "--loader".to_string(),
+                r"\EFI\Linux\linux-6.11.4-test.efi".to_string(),
+            ],
+            output: Ok(ProcessOutput::default()),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec!["--verbose".to_string()],
+            output: Ok(ProcessOutput {
+                stdout: "BootCurrent: 0001
+BootOrder: 0001,0007
+Boot0001* Fedora	HD(...)
+Boot0007* Linux UKI 6.11.4-test	HD(...)
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec!["--bootnext".to_string(), "0007".to_string()],
+            output: Ok(ProcessOutput::default()),
+        },
+        ExpectedCall {
+            program: "rpm".to_string(),
+            args: vec!["-q".to_string(), "kernel".to_string()],
+            output: Ok(ProcessOutput {
+                stdout: "kernel-6.11.4-test
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "bootctl".to_string(),
+            args: vec!["update".to_string()],
+            output: Ok(ProcessOutput::default()),
+        },
+    ]);
+
+    let mut cfg = AppConfig::default();
+    cfg.uki.auto_detect_cmdline = false;
+    cfg.uki.configured_cmdline = "root=/dev/test rw quiet".to_string();
+    let settings = GenerateSettings {
+        kernel_version: "6.11.4-test".to_string(),
+        esp_path: esp.clone(),
+        output_dir: out.clone(),
+        cmdline_file: cmdline,
+        splash: None,
+        os_release,
+    };
+
+    let installed = install(&runner, &cfg, &settings, true).unwrap_or_else(|e| panic!("{e:#}"));
+    assert_eq!(installed, final_out);
+    runner.assert_no_pending();
+
+    std::fs::remove_file(kernel_dir.join("vmlinuz")).ok();
+    std::fs::remove_dir(kernel_dir).ok();
+}
+
+#[test]
+fn confirm_promotes_current_boot_entry_to_front() {
+    let runner = MockRunner::new(vec![
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec!["--verbose".to_string()],
+            output: Ok(ProcessOutput {
+                stdout: "BootCurrent: 0007
+BootNext: 0007
+BootOrder: 0001,0007,0003
+Boot0001* Fedora	HD(...)
+Boot0003* Rescue	HD(...)
+Boot0007* Linux UKI 6.11.4-test	HD(...)
+"
+                .to_string(),
+                stderr: String::new(),
+            }),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec!["--bootorder".to_string(), "0007,0001,0003".to_string()],
+            output: Ok(ProcessOutput::default()),
+        },
+    ]);
+
+    let boot_num = confirm(&runner).unwrap_or_else(|e| panic!("{e:#}"));
+    assert_eq!(boot_num, "0007");
+    runner.assert_no_pending();
 }


### PR DESCRIPTION
### Motivation

- Provide a safer first-boot workflow that lets users trial a newly generated UKI exactly once via firmware `BootNext` before changing the permanent `BootOrder`.
- Automate scheduling and confirmation of one-time trial boots to reduce risk when replacing GRUB or updating boot entries.

### Description

- Add a `--boot-once` flag to generation/install paths by extending `GenerateArgs` and plumbing `boot_once` through `generate` and `install` to schedule a `BootNext` entry with `efibootmgr` via a new `schedule_one_time_boot` call.
- Make `register_boot_entry` return the new EFI boot number and implement `query_boot_state`, `parse_boot_state`, and `detect_new_entry_number` to determine the created boot entry reliably from `efibootmgr --verbose` output.
- Add a `confirm` command and `promote_current_boot_entry` that reads `BootCurrent` and moves that entry to the front of `BootOrder` via `efibootmgr --bootorder` to make the trial permanent.
- Update CLI (`src/cli.rs`) to accept `--boot-once` and new `Confirm` command, update `main.rs` wiring, and update `app.rs` to return the created boot number and message about scheduling; adjust `install`/`reconcile` flows accordingly.
- Extend README with a `Safer First Boot Workflow` section and examples demonstrating `--boot-once` and `confirm` usage.
- Add parsing and unit/integration tests for new functionality and update existing tests/fixtures to include the new `boot_once` flag.

### Testing

- Ran the unit tests including `efi::parse_boot_state` and `detect_new_entry_number` with `cargo test`, which passed.
- Ran the extended integration-style tests in `tests/integration_cli.rs` that cover `generate` with `--boot-once`, `install` with `--boot-once`, and `confirm`, and they passed.
- Existing test suite (sanity/unit tests) was executed via `cargo test` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb0efd4598832a95e245a01ef398a8)