### PR TITLE
Update roadmap, add Clippy CI, scope integration test allows, and fix Clippy warnings

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,6 +21,7 @@ jobs:
           dnf install -y \
             bash \
             cargo \
+            clippy \
             gcc \
             coreutils \
             diffutils \

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,6 +45,9 @@ jobs:
             cargo test --all-targets
           fi
 
+      - name: Rust Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
       - name: Rust compile check
         run: |
           if [[ -f Cargo.lock ]]; then

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ sudo cp target/release/rustyuki /usr/local/bin/
 
 ```bash
 rustyuki --version
+# rustyuki 0.2.0
 ```
 
 > [!NOTE]
@@ -513,17 +514,22 @@ These projects and tools shaped both the current implementation and the roadmap 
 ## Roadmap
 
 > [!NOTE]
-> The roadmap below incorporates ideas derived from comparing RustyUKI against **kraxel/fedora-uki** and **rhboot/nmbl-builder**, alongside features already planned for RustyUKI itself. Items remain grouped roughly by implementation effort and expected impact.
+> The roadmap below incorporates ideas derived from comparing RustyUKI against **kraxel/fedora-uki** and **rhboot/nmbl-builder**, alongside features already planned for RustyUKI itself. Shipped items were moved out so this section only tracks work that is still open.
+
+### Recently shipped
+
+- **BootNext trial boot workflow** — `--boot-once` now schedules a one-time trial boot and `rustyuki confirm` promotes the successful entry afterward.
+- **ESP preflight validation** — generation now checks mount presence, mount state, free space, and output directory writability before writing a UKI.
+- **Fedora `kernel-install` hook support** — RustyUKI can install a plugin so kernel add/remove events trigger reconciliation automatically.
+- **Multi-kernel reconciliation and stale artifact cleanup** — `rustyuki reconcile` rebuilds installed kernels and prunes stale `linux-*.efi` outputs.
+- **RPM workflow consolidation** — Fedora RPM CI and scheduled release automation now live in the single `rpm.yml` workflow.
 
 ### 1. Safety & Boot Entry Management
 
-- [ ] **`--boot-once` / BootNext trial boot** — add a safer first-boot workflow using `efibootmgr --bootnext`, plus a follow-up `rustyuki confirm` command to make a successfully tested UKI permanent.
 - [ ] **Secure Boot cmdline guard** — detect active Secure Boot, warn when cmdline changes require a rebuild/re-sign, and track cmdline hashes beside installed UKIs.
-- [ ] **ESP mount validation** — add preflight checks for mount state, read-write access, free space, and output directory writability before any build starts.
 
 ### 2. Fedora Integration
 
-- [ ] **`kernel-install` plugin** — ship a Fedora-friendly plugin so kernel add/remove events can automatically build or prune UKIs.
 - [ ] **Boot environment awareness in `status`** — surface EFI boot entry details via `kernel-bootcfg --show` when available, with `efibootmgr -v` as a fallback.
 - [ ] **GPT autodiscovery advisory** — detect discoverable root partitions and warn when `root=` is redundant or stale.
 - [ ] **Supported architectures** — keep short-term guards in place for x86_64-only assumptions today, while planning full aarch64 support later.
@@ -541,7 +547,6 @@ These projects and tools shaped both the current implementation and the roadmap 
 - [ ] **Atomic write with rollback slot** — preserve the previous UKI as a `.prev` image and add a `rustyuki rollback` command for recovery.
 - [ ] **Multi-profile UKI support** — allow multiple named build profiles from one config for default, recovery, cloud, or hardware-specific UKIs.
 - [ ] **Rootfs validation and fix-up** — cross-check `root=` against the running system in `status` and add a `rustyuki fix-cmdline` helper.
-- [ ] **Multi-kernel management** — continue improving kernel-version tracking and cleanup of stale UKIs and entries.
 - [ ] **Fallback UKI pinning** — protect a designated "last known good" UKI from accidental replacement.
 - [ ] **Automated pre-flight validation** — continue expanding built-in safety checks before every build.
 
@@ -549,7 +554,6 @@ These projects and tools shaped both the current implementation and the roadmap 
 
 - [ ] **Packaged releases** — publish pre-built binaries via GitHub Releases with SHA256 checksums.
 - [ ] **RPM spec packaging** — complete `dnf install rustyuki` support for Fedora-based systems.
-- [ ] **Workflow consolidation** — merge overlapping RPM workflows into a single `rpm.yml` pipeline with separate CI and release jobs.
 - [ ] **Clippy in CI** — add `cargo clippy --all-targets -- -D warnings` as a required check.
 - [ ] **Pinned Fedora container digests** — pin workflow container images for better reproducibility.
 

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -341,7 +341,7 @@ fn statvfs_free_bytes(path: &Path) -> Result<u64> {
     }
 
     let stats = unsafe { stats.assume_init() };
-    Ok((stats.f_bavail as u64).saturating_mul(stats.f_frsize as u64))
+    Ok(stats.f_bavail.saturating_mul(stats.f_frsize))
 }
 
 fn ensure_path_writable(path: &Path) -> Result<()> {

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -55,7 +55,7 @@ pub fn resolve_cmdline(runner: &dyn CommandRunner, settings: &CmdlineSettings) -
     let current_major = major_version(&version_id);
 
     if settings.auto_detect {
-        if let Some(cached) = load_cached_cmdline(settings, &version_id, &current_major)? {
+        if let Some(cached) = load_cached_cmdline(settings, &version_id, current_major)? {
             return validate_final_cmdline(
                 runner,
                 &cached.value,

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use anyhow::{anyhow, Result};
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -15,22 +14,31 @@ fn test_esp_mountpoint() -> PathBuf {
     panic!("no writable mount point available for ESP integration tests");
 }
 
+#[allow(dead_code)]
 #[path = "../src/app.rs"]
 mod app;
+#[allow(dead_code)]
 #[path = "../src/cli.rs"]
 mod cli;
+#[allow(dead_code)]
 #[path = "../src/cmd.rs"]
 mod cmd;
+#[allow(dead_code)]
 #[path = "../src/config.rs"]
 mod config;
+#[allow(dead_code)]
 #[path = "../src/dracut.rs"]
 mod dracut;
+#[allow(dead_code)]
 #[path = "../src/efi.rs"]
 mod efi;
+#[allow(dead_code)]
 #[path = "../src/error.rs"]
 mod error;
+#[allow(dead_code)]
 #[path = "../src/kernel.rs"]
 mod kernel;
+#[allow(dead_code)]
 #[path = "../src/ukify.rs"]
 mod ukify;
 


### PR DESCRIPTION
### Motivation

- Restore roadmap credibility by moving already-shipped items out of the open TODOs so the roadmap only lists outstanding work.  
- Enforce lint hygiene in CI by adding `cargo clippy --all-targets -- -D warnings`.  
- Reduce unsafe test-wide suppressions and scope `#[allow(dead_code)]` to only the module imports used by the integration harness.  
- Resolve the Clippy findings that would cause the new lint step to fail.

### Description

- Moved completed roadmap items into a new “Recently shipped” subsection in `README.md` and added the `rustyuki --version` example to the Verify step.  
- Inserted a Clippy step into the checks workflow at `.github/workflows/checks.yml` that runs `cargo clippy --all-targets -- -D warnings`.  
- Removed the file-wide `#![allow(dead_code)]` from `tests/integration_cli.rs` and added `#[allow(dead_code)]` to the individual `#[path = "../src/..."] mod ...;` module imports instead.  
- Fixed Clippy-reported issues: removed unnecessary casts in `src/efi.rs` (`statvfs` free bytes calculation) and removed an unnecessary borrow in `src/kernel.rs` when calling `load_cached_cmdline` so the code satisfies `clippy::unnecessary-cast` and `clippy::needless_borrow` diagnostics.

### Testing

- Ran `cargo test --all-targets` and all unit and integration tests passed.  
- Ran `cargo clippy --all-targets -- -D warnings` and the lint check completed successfully after the fixes.  
- Also ran `cargo fmt` during the edit sequence to keep formatting consistent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb24e34b10832aacb1d6d93f6fb05f)