### PR TITLE
Add GPT autodiscovery advisory to status output

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,7 @@ use crate::kernel::{
 use crate::ukify::{build_uki, UkifyParams};
 use anyhow::{Context, Result};
 use log::info;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Fully resolved runtime settings for generation.
@@ -205,8 +206,92 @@ pub fn status(runner: &dyn CommandRunner, cfg: &AppConfig) -> Result<String> {
     lines.push(format!("esp_path: {}", cfg.uki.esp_path.display()));
     lines.push(format!("output_dir: {}", cfg.uki.output_dir.display()));
     lines.push(format!("cmdline_file: {}", cfg.uki.cmdline_file.display()));
+
+    if let Some(advisory) = discoverable_root_advisory(runner, &cfg.uki.cmdline_file)? {
+        lines.push(advisory);
+    }
+
     lines.push(format!("os_release: {}", cfg.uki.os_release.display()));
     Ok(lines.join("\n"))
+}
+
+fn discoverable_root_advisory(
+    runner: &dyn CommandRunner,
+    cmdline_file: &Path,
+) -> Result<Option<String>> {
+    let cmdline = match fs::read_to_string(cmdline_file) {
+        Ok(content) => content,
+        Err(_) => return Ok(None),
+    };
+
+    let has_root = cmdline
+        .split_whitespace()
+        .any(|token| token.starts_with("root="));
+
+    let mounts = match fs::read_to_string("/proc/mounts") {
+        Ok(content) => content,
+        Err(_) => return Ok(None),
+    };
+
+    let Some(root_device) = parse_root_mount_source(&mounts) else {
+        return Ok(None);
+    };
+
+    if !root_device.starts_with("/dev/") {
+        return Ok(None);
+    }
+
+    let parttype = runner
+        .run("lsblk", &["-no", "PARTTYPE", &root_device])
+        .context("failed determining root partition GPT type GUID")?
+        .stdout
+        .trim()
+        .to_ascii_lowercase();
+
+    Ok(discoverable_root_message(
+        has_root,
+        &parttype,
+        std::env::consts::ARCH,
+    ))
+}
+
+fn discoverable_root_message(has_root: bool, parttype: &str, arch: &str) -> Option<String> {
+    let expected_guid = dps_root_guid(arch)?;
+    if parttype != expected_guid {
+        return None;
+    }
+
+    Some(if has_root {
+        [
+            "[INFO] Root partition carries a discoverable GPT GUID.",
+            "       'root=' in your cmdline may be unnecessary on this system.",
+            "       Consider removing it and testing with: rustyuki generate --dry-run",
+        ]
+        .join("\n")
+    } else {
+        "[OK] Cmdline has no 'root='. GPT autodiscovery will locate the root partition.".to_string()
+    })
+}
+
+fn parse_root_mount_source(proc_mounts: &str) -> Option<String> {
+    proc_mounts.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let source = fields.next()?;
+        let target = fields.next()?;
+        (target == "/").then(|| source.to_string())
+    })
+}
+
+fn dps_root_guid(arch: &str) -> Option<&'static str> {
+    match arch {
+        "x86_64" => Some("4f68bce3-e8cd-4db1-96e7-fbcaf984b709"),
+        "x86" | "i386" | "i586" | "i686" => Some("44479540-f297-41b2-9af7-d131d5f0458a"),
+        "arm" | "armv7" | "armv7l" => Some("69dad710-2ce4-4e3c-b16c-21a1d49abed3"),
+        "aarch64" => Some("b921b045-1df0-41c3-af44-4c6f280d3fae"),
+        "riscv64" => Some("72ec70a6-cf74-40e6-bd49-4bda08e8f224"),
+        "loongarch64" => Some("77055800-792c-4f94-b39a-98c91b762bb6"),
+        _ => None,
+    }
 }
 
 fn ensure_required_paths(settings: &GenerateSettings) -> Result<()> {
@@ -230,7 +315,10 @@ fn require_exists(path: &Path, label: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_generate_settings;
+    use super::{
+        discoverable_root_message, dps_root_guid, parse_root_mount_source,
+        resolve_generate_settings,
+    };
     use crate::cli::GenerateArgs;
     use crate::config::AppConfig;
 
@@ -249,5 +337,42 @@ mod tests {
 
         let resolved = resolve_generate_settings(&cfg, &args, "6.9.0-test");
         assert_eq!(resolved.kernel_version, "6.9.0-test");
+    }
+
+    #[test]
+    fn parse_root_mount_source_finds_root_device() {
+        let mounts = "/dev/mapper/root / xfs rw,relatime 0 0\n/dev/nvme0n1p1 /boot vfat rw 0 0\n";
+        assert_eq!(
+            parse_root_mount_source(mounts).as_deref(),
+            Some("/dev/mapper/root")
+        );
+    }
+
+    #[test]
+    fn dps_root_guid_knows_x86_64() {
+        assert_eq!(
+            dps_root_guid("x86_64"),
+            Some("4f68bce3-e8cd-4db1-96e7-fbcaf984b709")
+        );
+    }
+
+    #[test]
+    fn discoverable_root_message_warns_when_root_token_present() {
+        let message =
+            discoverable_root_message(true, "4f68bce3-e8cd-4db1-96e7-fbcaf984b709", "x86_64")
+                .unwrap_or_else(|| panic!("missing message"));
+        assert!(message.contains("[INFO] Root partition carries a discoverable GPT GUID."));
+        assert!(message.contains("'root=' in your cmdline may be unnecessary"));
+    }
+
+    #[test]
+    fn discoverable_root_message_confirms_when_root_token_missing() {
+        let message =
+            discoverable_root_message(false, "4f68bce3-e8cd-4db1-96e7-fbcaf984b709", "x86_64")
+                .unwrap_or_else(|| panic!("missing message"));
+        assert_eq!(
+            message,
+            "[OK] Cmdline has no 'root='. GPT autodiscovery will locate the root partition."
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Make `rustyuki status` aware of Discoverable Partitions Specification (DPS) so users get a helpful advisory when their root partition already carries a discoverable GPT type GUID. 
- Avoid silently baking redundant or fragile `root=` cmdline tokens into UKIs by providing advisory (not automatic) guidance to remove them when GPT autodiscovery will work.

### Description
- Implemented `discoverable_root_advisory` in `src/app.rs` which reads the configured cmdline file, checks for a `root=` token, reads `/proc/mounts` to find the device mounted at `/`, and queries `lsblk -no PARTTYPE` for that device to obtain the partition GPT type GUID. 
- Added `dps_root_guid` mapping for architecture-specific DPS root GUIDs and `parse_root_mount_source` helper to extract `/` mount source. 
- Added `discoverable_root_message` to format the two advisory outputs: an `[INFO]` advisory when `root=` is present and the partition GUID matches DPS, and an `[OK]` confirmation when `root=` is absent and the GUID matches; the code emits no automatic changes to the cmdline file. 
- Updated tests and added unit coverage for root mount parsing, DPS GUID lookup, and both advisory message paths, and adjusted the `status` integration test to use a temporary cmdline file; changes are all in `src/app.rs` and test updates in `tests/integration_cli.rs`.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully. 
- Ran the full test suite with `cargo test` which completed successfully; all unit and integration tests passed. 
- Existing status/integration tests were updated to exercise the new advisory behavior and the new unit tests cover the parsing and message logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb504c3104832a9332d6559ec60a22)