### PR TITLE
Handle kernel-install events safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ rustyuki --version
 # rustyuki 0.2.0
 ```
 
+### Activate automatic UKI rebuilds on kernel updates
+```bash
+sudo rustyuki install-hook
+```
+
+This installs a `kernel-install` plugin at `/usr/lib/kernel/install.d/90-rustyuki.install`. After this, every `dnf update kernel` or kernel package transaction will automatically rebuild or prune your UKIs without any manual intervention.
+
 > [!NOTE]
 > Pre-built binaries and RPM packages are planned for a future release. See [Roadmap](#roadmap).
 
@@ -520,7 +527,7 @@ These projects and tools shaped both the current implementation and the roadmap 
 
 - **BootNext trial boot workflow** — `--boot-once` now schedules a one-time trial boot and `rustyuki confirm` promotes the successful entry afterward.
 - **ESP preflight validation** — generation now checks mount presence, mount state, free space, and output directory writability before writing a UKI.
-- **Fedora `kernel-install` hook support** — RustyUKI can install a plugin so kernel add/remove events trigger reconciliation automatically.
+- **Fedora `kernel-install` hook support** — RustyUKI can install a plugin so kernel add/remove events now trigger targeted UKI generation on adds and reconciliation on removals automatically.
 - **Multi-kernel reconciliation and stale artifact cleanup** — `rustyuki reconcile` rebuilds installed kernels and prunes stale `linux-*.efi` outputs.
 - **RPM workflow consolidation** — Fedora RPM CI and scheduled release automation now live in the single `rpm.yml` workflow.
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -37,7 +37,7 @@ pub fn render_kernel_install_plugin(binary: &Path, config: &Path) -> Result<Stri
 
     Ok(format!(
         r#"#!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 COMMAND="${{1:-}}"
 KERNEL_VER="${{2:-unknown}}"
@@ -50,22 +50,28 @@ log() {{
 
 if [[ ! -x "$RUSTYUKI_BIN" ]]; then
   log "RustyUKI binary not executable: $RUSTYUKI_BIN"
-  exit 1
+  exit 0
 fi
 
 case "$COMMAND" in
   add)
-    log "kernel add: $KERNEL_VER; reconciling all installed kernels"
+    log "kernel add: $KERNEL_VER — building UKI for this kernel only"
+    if ! "$RUSTYUKI_BIN" --config "$RUSTYUKI_CONFIG" generate --kernel-version "$KERNEL_VER"; then
+      log "warning: generate failed for kernel $KERNEL_VER; leaving transaction successful"
+    fi
     ;;
   remove)
-    log "kernel remove: $KERNEL_VER; reconciling all installed kernels"
+    log "kernel remove: $KERNEL_VER — reconciling all installed kernels"
+    if ! "$RUSTYUKI_BIN" --config "$RUSTYUKI_CONFIG" reconcile; then
+      log "warning: reconcile failed after removing kernel $KERNEL_VER; leaving transaction successful"
+    fi
     ;;
   *)
-    log "kernel command '$COMMAND'; running reconcile"
+    log "unknown command '$COMMAND' — skipping"
     ;;
 esac
 
-exec "$RUSTYUKI_BIN" --config "$RUSTYUKI_CONFIG" reconcile
+exit 0
 "#
     ))
 }
@@ -86,5 +92,57 @@ mod tests {
         assert!(script.contains("reconcile"));
         assert!(script.contains("--config \"$RUSTYUKI_CONFIG\""));
         assert!(script.contains("KERNEL_VER"));
+    }
+
+    #[test]
+    fn plugin_uses_generate_for_add() {
+        let script = render_kernel_install_plugin(
+            Path::new("/usr/local/bin/rustyuki"),
+            Path::new("/etc/uki/uki.conf"),
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        assert!(script.contains("add)"));
+        assert!(script.contains("generate --kernel-version \"$KERNEL_VER\""));
+    }
+
+    #[test]
+    fn plugin_uses_reconcile_for_remove() {
+        let script = render_kernel_install_plugin(
+            Path::new("/usr/local/bin/rustyuki"),
+            Path::new("/etc/uki/uki.conf"),
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let remove_section = script
+            .split("remove)")
+            .nth(1)
+            .and_then(|section| section.split("*)").next())
+            .unwrap_or("");
+        assert!(remove_section.contains("reconcile"));
+    }
+
+    #[test]
+    fn plugin_exits_zero_on_binary_missing() {
+        let script = render_kernel_install_plugin(
+            Path::new("/usr/local/bin/rustyuki"),
+            Path::new("/etc/uki/uki.conf"),
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        assert!(script.contains("RustyUKI binary not executable: $RUSTYUKI_BIN"));
+        assert!(script.contains("exit 0"));
+        assert!(!script.contains("exit 1"));
+    }
+
+    #[test]
+    fn plugin_does_not_use_exec() {
+        let script = render_kernel_install_plugin(
+            Path::new("/usr/local/bin/rustyuki"),
+            Path::new("/etc/uki/uki.conf"),
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        assert!(!script.contains("exec "));
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure kernel add/remove RPM transactions never fail due to RustyUKI errors while making add events fast by only building the newly added kernel.

### Description

- Replace the generated `/usr/lib/kernel/install.d` plugin script to use `set -uo pipefail`, avoid `exec`, and explicitly handle `$COMMAND` so `add` runs `rustyuki generate --kernel-version "$KERNEL_VER"` and `remove` runs `rustyuki reconcile`.
- Treat a missing RustyUKI binary as non-fatal (log to stderr and `exit 0`) and capture subcommand failures to log a warning but still exit `0` so RPM/DNF transactions remain successful.
- Add unit tests for the rendered script covering the `add` path (`generate --kernel-version`), `remove` path (`reconcile`), binary-missing zero-exit behavior, and absence of `exec` in the script.
- Update `README.md` Installation section to include `sudo rustyuki install-hook` and mark the kernel-install hook support as shipped in the Roadmap notes.

### Testing

- Ran `cargo fmt --check`, which succeeded.
- Ran `cargo test`, which succeeded (all new and existing unit and integration tests passed).
- Ran `cargo clippy --all-targets -- -D warnings`, which succeeded with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb5bb967c8832aaa16534437a7dfb1)