### PR TITLE
Implement BootNext trial-boot flow with automatic systemd boot-confirm service

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,18 +220,19 @@ Use `--boot-once` when you want firmware to trial the new UKI exactly once via `
 
 #### `install` — Generate and sync the ESP
 
-Identical to `generate`, followed by `bootctl update` to synchronise the ESP.
+`install` now always uses a trial-boot flow:
+
+1. Generates and registers the UKI entry without rewriting permanent `BootOrder`
+2. Sets the new entry as `BootNext` (one-time next boot)
+3. Installs/enables `rustyuki-boot-confirm.service`
+4. Runs `bootctl update` to synchronise the ESP
 
 ```bash
 sudo rustyuki install
 sudo rustyuki install --kernel-version "6.12.0-200.fc41.x86_64"
 ```
 
-Add `--boot-once` to schedule the new EFI entry as the next boot only via `efibootmgr --bootnext`, leaving your permanent `BootOrder` unchanged until you confirm the trial boot succeeded. The same flag is available on `generate` if you only want to register the UKI entry without running `bootctl update`.
-
-```bash
-sudo rustyuki install --boot-once
-```
+Use `generate --boot-once` if you want one-time trial semantics without running `bootctl update`.
 
 #### `reconcile` — Rebuild all installed kernel UKIs and prune stale artifacts
 
@@ -243,7 +244,7 @@ sudo rustyuki reconcile
 
 #### `confirm` — Make a successful trial boot permanent
 
-After booting the one-time UKI successfully, run `confirm` from that booted system. RustyUKI reads `BootCurrent` and moves that entry to the front of `BootOrder`, making the tested UKI your permanent default.
+After booting the one-time UKI successfully, `rustyuki-boot-confirm.service` runs automatically early in userspace and calls `rustyuki confirm`. `confirm` reads `BootCurrent`, moves that entry to the front of `BootOrder`, and clears `BootNext`.
 
 ```bash
 sudo rustyuki confirm
@@ -265,12 +266,12 @@ For first-time GRUB replacement or any risky UKI change, prefer a one-time boot 
 
 ```bash
 # Build the UKI, refresh the ESP, and schedule it for the next boot only
-sudo rustyuki install --boot-once
+sudo rustyuki install
 
 # Reboot normally; firmware will use BootNext exactly once
 sudo reboot
 
-# If the system came back successfully from the UKI, make it permanent
+# Optional manual confirmation (normally done automatically by systemd service)
 sudo rustyuki confirm
 ```
 
@@ -289,12 +290,12 @@ sudo rustyuki status
 sudo rustyuki generate --dry-run
 
 # Step 3 — build and schedule a one-time trial boot
-sudo rustyuki install --boot-once
+sudo rustyuki install
 
 # Step 4 — reboot normally and let BootNext test the UKI once
 sudo reboot
 
-# Step 5 — after a successful UKI boot, make it permanent
+# Step 5 — optional manual confirmation (auto-confirm service handles this on success)
 sudo rustyuki confirm
 ```
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use crate::dracut::build_initramfs;
 use crate::efi::{
     promote_current_boot_entry, register_boot_entry, schedule_one_time_boot, validate_esp_preflight,
 };
+use crate::hook::install_boot_confirm_service;
 use crate::kernel::{
     list_installed_kernels, prune_stale_uki_artifacts, resolve_cmdline, CmdlineSettings,
 };
@@ -140,11 +141,23 @@ pub fn install(
     runner: &dyn CommandRunner,
     cfg: &AppConfig,
     settings: &GenerateSettings,
-    boot_once: bool,
 ) -> Result<PathBuf> {
     validate_esp_preflight(&settings.esp_path, &settings.output_dir)?;
 
-    let (path, _boot_num) = generate(runner, cfg, settings, boot_once)?;
+    let current_exe =
+        std::env::current_exe().context("failed resolving current executable path")?;
+    install_boot_confirm_service(
+        Path::new("/etc/systemd/system/rustyuki-boot-confirm.service"),
+        &current_exe,
+    )?;
+    runner
+        .run("systemctl", &["daemon-reload"])
+        .context("failed to reload systemd units after installing rustyuki-boot-confirm.service")?;
+    runner
+        .run("systemctl", &["enable", "rustyuki-boot-confirm.service"])
+        .context("failed enabling rustyuki-boot-confirm.service")?;
+
+    let (path, _boot_num) = generate(runner, cfg, settings, true)?;
 
     let installed = list_installed_kernels(runner)?;
     let removed = prune_stale_uki_artifacts(&settings.output_dir, &installed)?;

--- a/src/efi.rs
+++ b/src/efi.rs
@@ -149,6 +149,7 @@ pub fn register_boot_entry(
         &[
             "--quiet",
             "--create",
+            "--create-only",
             "--disk",
             &format!("/dev/{disk}"),
             "--part",
@@ -202,6 +203,9 @@ pub fn promote_current_boot_entry(runner: &dyn CommandRunner) -> Result<String> 
     runner
         .run("efibootmgr", &["--bootorder", &boot_order_arg])
         .with_context(|| format!("failed setting BootOrder to {boot_order_arg}"))?;
+    runner
+        .run("efibootmgr", &["--delete-bootnext"])
+        .context("failed clearing BootNext after confirmation")?;
     Ok(current)
 }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -76,9 +76,55 @@ exit 0
     ))
 }
 
+pub fn install_boot_confirm_service(unit_path: &Path, binary: &Path) -> Result<()> {
+    let parent = unit_path.parent().with_context(|| {
+        format!(
+            "systemd unit path has no parent directory: {}",
+            unit_path.display()
+        )
+    })?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed creating unit directory {}", parent.display()))?;
+
+    let unit = render_boot_confirm_service(binary)?;
+    fs::write(unit_path, unit)
+        .with_context(|| format!("failed writing unit {}", unit_path.display()))?;
+
+    let mut perms = fs::metadata(unit_path)
+        .with_context(|| format!("failed stat {}", unit_path.display()))?
+        .permissions();
+    perms.set_mode(0o644);
+    fs::set_permissions(unit_path, perms)
+        .with_context(|| format!("failed chmod 0644 {}", unit_path.display()))?;
+
+    Ok(())
+}
+
+pub fn render_boot_confirm_service(binary: &Path) -> Result<String> {
+    let bin = binary
+        .to_str()
+        .with_context(|| format!("binary path is non-UTF8: {}", binary.display()))?;
+
+    Ok(format!(
+        r#"[Unit]
+Description=Confirm successful RustyUKI trial boot
+DefaultDependencies=no
+After=local-fs.target
+Before=network.target
+
+[Service]
+Type=oneshot
+ExecStart={bin} confirm
+
+[Install]
+WantedBy=multi-user.target
+"#
+    ))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::render_kernel_install_plugin;
+    use super::{render_boot_confirm_service, render_kernel_install_plugin};
     use std::path::Path;
 
     #[test]
@@ -144,5 +190,16 @@ mod tests {
         .unwrap_or_else(|e| panic!("{e}"));
 
         assert!(!script.contains("exec "));
+    }
+
+    #[test]
+    fn boot_confirm_service_has_early_userspace_ordering() {
+        let unit = render_boot_confirm_service(Path::new("/usr/local/bin/rustyuki"))
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        assert!(unit.contains("Type=oneshot"));
+        assert!(unit.contains("After=local-fs.target"));
+        assert!(unit.contains("Before=network.target"));
+        assert!(unit.contains("ExecStart=/usr/local/bin/rustyuki confirm"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn run() -> Result<()> {
         Commands::Install(args) => {
             let uname = current_kernel(&runner)?;
             let settings = resolve_generate_settings(&cfg, args, &uname);
-            let _ = install(&runner, &cfg, &settings, args.boot_once)?;
+            let _ = install(&runner, &cfg, &settings)?;
         }
         Commands::Reconcile => {
             let uname = current_kernel(&runner)?;

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -36,6 +36,9 @@ mod efi;
 #[path = "../src/error.rs"]
 mod error;
 #[allow(dead_code)]
+#[path = "../src/hook.rs"]
+mod hook;
+#[allow(dead_code)]
 #[path = "../src/kernel.rs"]
 mod kernel;
 #[allow(dead_code)]
@@ -507,6 +510,7 @@ Boot0001* Fedora	HD(...)
             args: vec![
                 "--quiet".to_string(),
                 "--create".to_string(),
+                "--create-only".to_string(),
                 "--disk".to_string(),
                 "/dev/nvme0n1".to_string(),
                 "--part".to_string(),
@@ -562,7 +566,7 @@ Boot0008* Linux UKI 6.11.5-test	HD(...)
 }
 
 #[test]
-fn install_with_boot_once_sets_bootnext_after_bootctl_update() {
+fn install_sets_bootnext_after_bootctl_update() {
     let temp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
     let esp = test_esp_mountpoint();
     let out = esp.join("EFI/Linux");
@@ -585,6 +589,19 @@ fn install_with_boot_once_sets_bootnext_after_bootctl_update() {
     let final_out = out.join("linux-6.11.4-test.efi");
 
     let runner = MockRunner::new(vec![
+        ExpectedCall {
+            program: "systemctl".to_string(),
+            args: vec!["daemon-reload".to_string()],
+            output: Ok(ProcessOutput::default()),
+        },
+        ExpectedCall {
+            program: "systemctl".to_string(),
+            args: vec![
+                "enable".to_string(),
+                "rustyuki-boot-confirm.service".to_string(),
+            ],
+            output: Ok(ProcessOutput::default()),
+        },
         ExpectedCall {
             program: "dracut".to_string(),
             args: vec![
@@ -671,6 +688,7 @@ Boot0001* Fedora	HD(...)
             args: vec![
                 "--quiet".to_string(),
                 "--create".to_string(),
+                "--create-only".to_string(),
                 "--disk".to_string(),
                 "/dev/nvme0n1".to_string(),
                 "--part".to_string(),
@@ -729,7 +747,7 @@ Boot0007* Linux UKI 6.11.4-test	HD(...)
         os_release,
     };
 
-    let installed = install(&runner, &cfg, &settings, true).unwrap_or_else(|e| panic!("{e:#}"));
+    let installed = install(&runner, &cfg, &settings).unwrap_or_else(|e| panic!("{e:#}"));
     assert_eq!(installed, final_out);
     runner.assert_no_pending();
 
@@ -759,6 +777,11 @@ Boot0007* Linux UKI 6.11.4-test	HD(...)
         ExpectedCall {
             program: "efibootmgr".to_string(),
             args: vec!["--bootorder".to_string(), "0007,0001,0003".to_string()],
+            output: Ok(ProcessOutput::default()),
+        },
+        ExpectedCall {
+            program: "efibootmgr".to_string(),
+            args: vec!["--delete-bootnext".to_string()],
             output: Ok(ProcessOutput::default()),
         },
     ]);


### PR DESCRIPTION
### Motivation

- Prevent `install` from immediately mutating firmware `BootOrder` and instead perform safer one-time trial boots via `BootNext` so the previous entry remains the fallback if the trial fails. 
- Provide automatic, early-userspace confirmation so a successful trial boot is promoted to the permanent boot order without requiring a manual step. 

### Description

- Use `efibootmgr --create --create-only` when registering a new UKI entry so creation does not rewrite `BootOrder`. 
- Add `install_boot_confirm_service()` and `render_boot_confirm_service()` in `src/hook.rs` to render and write a `rustyuki-boot-confirm.service` systemd oneshot unit that runs early in userspace and invokes `rustyuki confirm`. 
- Update `install()` in `src/app.rs` to install the service unit, run `systemctl daemon-reload`, `systemctl enable rustyuki-boot-confirm.service`, and call `generate(..., true)` so `install` always stages the new entry as a one-time `BootNext` trial. 
- Change `promote_current_boot_entry()` in `src/efi.rs` to clear `BootNext` after promoting `BootCurrent` by running `efibootmgr --delete-bootnext`. 
- Adjust CLI dispatch in `src/main.rs` so `Install` calls the new `install(&runner, &cfg, &settings)` signature. 
- Update tests in `tests/integration_cli.rs` and unit tests to expect `--create-only`, the new `systemctl` calls during `install`, and `--delete-bootnext` during confirmation, and to add the `hook` module for compilation. 
- Revise `README.md` to document the new install-as-trial semantics and the automatic confirmation service, and to show `sudo rustyuki install` as the trial flow. 

### Testing

- Ran `cargo test`; all automated tests passed successfully, including unit tests (22 passed) and integration tests (34 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab62496dc832a8594e749565fe327)